### PR TITLE
【修复，脚本】修正 prerelease 版本比较

### DIFF
--- a/scripts/should-upgrade.sh
+++ b/scripts/should-upgrade.sh
@@ -12,10 +12,13 @@ LATEST="$2"
 
 [ "$CURRENT" = "$LATEST" ] && { echo 0; exit 0; }
 
-# npx semver：latest 满足 >current 时输出自身，否则输出空
-# simp: 借 npm 生态 semver 实现，避免自写版本比较（prerelease 如 0.1.0-rc.6 的排序规则易错）
+# npx semver 无参时按优先级升序打印；latest 排最后则严格更新
+# simp: 借 npm 生态 semver 做纯排序，不用 range。>current 默认只匹配同元组
+# prerelease（0.1.1-rc.2 不满足 >0.1.0-rc.7），正是自动升级卡住的原因
 #
-# npx semver: echoes latest when it satisfies >current, otherwise empty
-# simp: reuse the npm semver CLI instead of hand-rolling comparison (prerelease ordering like 0.1.0-rc.6 is error-prone)
-UPDATED="$(npx --yes semver@7 -r ">$CURRENT" "$LATEST" 2>/dev/null || true)"
-[ -n "$UPDATED" ] && echo 1 || echo 0
+# npx semver with no flags prints versions in ascending precedence; latest is
+# strictly newer if it sorts last. simp: reuse npm semver as a pure sort, not a
+# range. >current by default only matches same-tuple prereleases (0.1.1-rc.2
+# does not satisfy >0.1.0-rc.7 — why auto-upgrade stalled)
+HIGHER="$(npx --yes semver@7 "$CURRENT" "$LATEST" 2>/dev/null | tail -n1 || true)"
+[ "$HIGHER" = "$LATEST" ] && echo 1 || echo 0

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -39,6 +39,14 @@ assert_eq "patch 升级应升级"          1 "$("$SU" 0.1.0 0.1.1)"
 assert_eq "minor 升级应升级"          1 "$("$SU" 0.1.0 0.2.0)"
 assert_eq "上游回退（降级）不升级"    0 "$("$SU" 0.1.0-rc.6 0.1.0-rc.5)"
 assert_eq "正式版后的 rc 不升级"      0 "$("$SU" 0.1.0 0.1.0-rc.9)"
+# 同元组更高 rc 原本就能过；跨元组 prerelease 才是 range 默认规则的盲区
+# （>0.1.0-rc.7 不匹配 0.1.1-rc.2，正是自动升级卡住的原因）
+#
+# A higher rc in the same tuple already passed; cross-tuple prereleases are the
+# range default's blind spot (>0.1.0-rc.7 does not match 0.1.1-rc.2 — why auto-upgrade stalled)
+assert_eq "同元组更高 rc 应升级"      1 "$("$SU" 0.1.0-rc.7 0.1.0-rc.8)"
+assert_eq "跨元组 prerelease 应升级"  1 "$("$SU" 0.1.0-rc.7 0.1.1-rc.2)"
+assert_eq "跨元组 alpha 应升级"       1 "$("$SU" 0.1.0-rc.7 0.1.2-alpha.1)"
 
 echo "== upgrade-dsh.sh（文件更新）=="
 # fixture：直接从仓库复制当前文件（模拟"升级前"状态）


### PR DESCRIPTION
## 原因

`should-upgrade.sh` 用 `npx semver -r ">current" latest` 判断是否升级。semver 的 range 默认不跨元组匹配 prerelease：`0.1.1-rc.2` 不满足 `>0.1.0-rc.7`，CI 因此把 `should_upgrade` 判成 `false`。

实测：`check-dsh-upstream` 在 `current=0.1.0-rc.7`、`latest=0.1.1-rc.2` 时仍输出 `should_upgrade=false`。同元组更高 rc（`0.1.0-rc.8`）能过，所以仓库停在 `0.1.0-rc.7` 后就再也跟不上。

## 修复

改为 `npx semver` 纯排序：latest 排在 current 之后才升级。不用 range，也不用 `-p`（后者会把正式版之后的同 patch rc 误判为更新）。

补了跨元组用例：`0.1.0-rc.7 → 0.1.1-rc.2`、`0.1.0-rc.7 → 0.1.2-alpha.1`。`tests/test-scripts.sh` 37 通过。