### PR TITLE
【修复，脚本】为失败 Issue 创建步骤补 GH_TOKEN

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -142,3 +142,10 @@ jobs:
         env:
           LATEST: ${{ needs.check.outputs.latest }}
           CURRENT: ${{ needs.check.outputs.current }}
+          # GH_TOKEN 显式透传：与「触发 GHCR 发布」对齐，避免 gh 因无凭据报错
+          # (open-issue.sh 内部亦有 GITHUB_TOKEN 兜底，这是双层防御)
+          #
+          # Pass GH_TOKEN explicitly: matches the "Hook GHCR release" step; prevents gh from
+          # failing for lack of credentials. open-issue.sh also falls back to GITHUB_TOKEN,
+          # so this is belt-and-suspenders
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/open-issue.sh
+++ b/scripts/open-issue.sh
@@ -7,11 +7,22 @@
 # 测试注入：设置 GH=/path/to/mock 可替换 gh 命令（用于单测）
 #
 # Test injection: set GH=/path/to/mock to substitute the gh command (used by unit tests)
+#
+# GitHub Actions 兜底：在 CI 环境中 gh 默认从 GH_TOKEN 取凭据；若调用方未显式设置
+# （早期版本漏配），自动回退到 GITHUB_TOKEN。这是双层防御：GH_TOKEN 优先，未设置则用 GITHUB_TOKEN，
+# 调用方仍可显式传 GH_TOKEN 覆盖（例如指向 PAT）
+#
+# GitHub Actions fallback: gh reads GH_TOKEN for credentials by default. If a caller forgets
+# to set it (an earlier workflow did), fall back to GITHUB_TOKEN. Belt-and-suspenders:
+# GH_TOKEN wins when set; otherwise GITHUB_TOKEN is used; callers can still pin GH_TOKEN
+# explicitly (e.g. to a PAT)
 set -euo pipefail
 
 LATEST="$1"
 CURRENT="$2"
 GH_BIN="${GH:-gh}"
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
 TITLE="[自动升级] dsh 上游 $LATEST 构建冒烟测试失败"
 
 EXISTING="$("$GH_BIN" issue list --state open --search "in:title \"$TITLE\"" --json number -q '.[0].number' 2>/dev/null || true)"

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -144,6 +144,33 @@ MOCK_LOG="$TMP/mock2.log" MOCK_LIST_OUT='[{"number":7}]' GH="$MOCK_GH" \
 assert_grep "已有同版本 Issue 时跳过"         "已存在同版本 Issue #7" "$TMP/issue2.out"
 assert_no_grep "去重时不调用 create"          "issue create" "$TMP/mock2.log"
 
+# GitHub Actions 兜底：仅设 GITHUB_TOKEN 时，脚本应将其映射为 GH_TOKEN 并透传给 gh
+# (upstream-check.yml 早期版本漏配 env，导致 exit 4 的根因)
+#
+# GitHub Actions fallback: when only GITHUB_TOKEN is set, the script must surface it as
+# GH_TOKEN to gh. (This is the root cause of the upstream-check.yml exit-4 failure before
+# the env was wired up)
+GH_TOKEN_GUARD="$TMP/gh-token-guard"
+cat > "$GH_TOKEN_GUARD" <<'GUARD'
+#!/usr/bin/env bash
+echo "GH_TOKEN=${GH_TOKEN-unset}" >> "${GUARD_LOG:?}"
+exec "$GH_REAL" "$@"
+GUARD
+chmod +x "$GH_TOKEN_GUARD"
+GUARD_LOG="$TMP/mock_guard.log" MOCK_LOG="$TMP/mock_guard_gh.log" MOCK_LIST_OUT='[]' \
+  GH="$GH_TOKEN_GUARD" GH_REAL="$MOCK_GH" \
+  GITHUB_TOKEN=ghp_ci_fallback \
+  "$OPEN_ISSUE" 0.2.0 0.1.0-rc.6 > "$TMP/issue_guard.out" 2>&1
+assert_grep "GITHUB_TOKEN 兜底为 GH_TOKEN" "GH_TOKEN=ghp_ci_fallback" "$TMP/mock_guard.log"
+# 显式 GH_TOKEN 应优先于 GITHUB_TOKEN（避免 CI 中被无关变量意外覆盖）
+#
+# Explicit GH_TOKEN must win over GITHUB_TOKEN (so unrelated CI vars cannot clobber it)
+GUARD_LOG="$TMP/mock_guard2.log" MOCK_LOG="$TMP/mock_guard2_gh.log" MOCK_LIST_OUT='[]' \
+  GH="$GH_TOKEN_GUARD" GH_REAL="$MOCK_GH" \
+  GH_TOKEN=ghp_explicit GITHUB_TOKEN=ghp_should_lose \
+  "$OPEN_ISSUE" 0.2.0 0.1.0-rc.6 > "$TMP/issue_guard2.out" 2>&1
+assert_grep "显式 GH_TOKEN 优先" "GH_TOKEN=ghp_explicit" "$TMP/mock_guard2.log"
+
 echo "== check-issue-gate.sh (mock gh)=="
 GATE="$ROOT/scripts/check-issue-gate.sh"
 GATE_LIST='[{"title":"[自动升级] dsh 上游 0.2.0 构建冒烟测试失败","number":5}]'


### PR DESCRIPTION
## 背景 | Context

run 101662365815 在「失败时创建 Issue」步骤失败:

    gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
    Error: Process completed with exit code 4.

根因: `upstream-check.yml` 的失败时创建 Issue 步骤调 `scripts/open-issue.sh`,
脚本内 `gh` 调用要求 `GH_TOKEN`,但该步骤的 `env:` 漏配(同文件「触发 GHCR 发布」
步骤是对的,这一步漏了)。

## 修复 | Fix

双层防御:

1. **工作流显式透传**: `失败时创建 Issue` 步骤加 `GH_TOKEN: ${{ github.token }}`,
   与同文件「触发 GHCR 发布」对齐
2. **脚本兜底**: `open-issue.sh` 新增 `GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"`
   + `export`,任何未来调用方忘配 env 仍可工作;显式 `GH_TOKEN` 仍优先(支持 PAT)

## 测试 | Tests

`tests/test-scripts.sh` 新增两条 case:
- `GITHUB_TOKEN 兜底为 GH_TOKEN`: 仅设 `GITHUB_TOKEN`,断言 `gh` 收到正确的凭据
- `显式 GH_TOKEN 优先`: 同时设两个变量,断言 `GH_TOKEN` 胜出

全量 **39/39 通过**(原 37 + 新增 2)。

## 影响 | Impact

- 失败的自动升级现在会正确创建 Issue(此前直接退出 4,Issue 也建不出来,失败信息无人跟踪)
- 已成功路径不受影响(显式 `GH_TOKEN` 仅在调用方提供时生效,默认值 `gh` 已能处理无 token)