### PR TITLE
【更改，构建】全面适配 dsh 0.1.2-rc.1+ 鉴权（token+cookie）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,17 @@
 # 复制为 .env 后编辑（.env 不入库，含敏感信息）
 #
 # Copy to .env and edit (.env is not committed; it contains sensitive info)
+#
+# ⚠️ 升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时,必须先 `git pull` 同步
+# docker-compose.yml / Caddyfile / entrypoint.sh(以及其 token 抓取后台任务),仅
+# `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy
+# 且 web 服务裸奔(无鉴权)。详见 PR #7 commit message 与 README Quick Start。
+#
+# ⚠️ Upgrade warning — to upgrade to a version with dsh 0.1.2-rc.1+ auth migration,
+# you must `git pull` first to sync docker-compose.yml / Caddyfile / entrypoint.sh
+# (and its token-extraction background task). `docker compose pull` alone (new image,
+# old compose file) leaves healthcheck permanently unhealthy AND exposes the web
+# service without auth. See PR #7 commit message and README Quick Start for details.
 
 # dsh 0.1.2-rc.1+：鉴权迁回 dsh 自身（一次性 token + 持久 cookie），caddy basic auth 已移除。
 # 下面两个变量自 0.1.2-rc.1 起不再被 caddy 使用，**仅在回退到 ≤0.1.1-rc.2 时生效**——

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ DSH_WEB_PORT=3080
 # The Caddy loopback rewrite covers regular access by default)
 #DSH_TRUSTED_HOSTS=dsh.example.com,example.org
 
-# dsh 版本（构建期，可选；默认 0.1.0-rc.6，改后需 --build 重建镜像）
+# dsh 版本（构建期，可选；默认 0.1.2-rc.1，改后需 --build 重建镜像）
 #
-# dsh version (build-time, optional; default 0.1.0-rc.6; rebuild with --build after changing)
-#DSH_VERSION=0.1.0-rc.6
+# dsh version (build-time, optional; default 0.1.2-rc.1; rebuild with --build after changing)
+#DSH_VERSION=0.1.2-rc.1

--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,15 @@
 #
 # Copy to .env and edit (.env is not committed; it contains sensitive info)
 
-# basic auth 用户名（必填）| Basic auth username (required)
-DSH_AUTH_USER=admin
-
-# basic auth 明文密码（必填，容器启动时自动生成 bcrypt 哈希）
+# dsh 0.1.2-rc.1+：鉴权迁回 dsh 自身（一次性 token + 持久 cookie），caddy basic auth 已移除。
+# 下面两个变量自 0.1.2-rc.1 起不再被 caddy 使用，**仅在回退到 ≤0.1.1-rc.2 时生效**——
+# 留作兼容位，默认值仍按旧版填写；不修改即可平滑运行新版本（无副作用，仅占用 .env 几行）
 #
-# Basic auth plaintext password (required; a bcrypt hash is auto-generated at container startup)
+# dsh 0.1.2-rc.1+: authentication moved into dsh itself (one-time token + persistent cookie);
+# Caddy basic auth is removed. The two variables below are unused by Caddy since 0.1.2-rc.1
+# and only take effect on a rollback to ≤0.1.1-rc.2 — kept for compatibility, defaults
+# unchanged (no side effects on 0.1.2-rc.1+; just a few .env lines)
+DSH_AUTH_USER=admin
 DSH_AUTH_PASSWORD=change-me
 
 # DeepSeek API Key（必填，settings.yaml 经 apiKeyEnv 引用）

--- a/Caddyfile
+++ b/Caddyfile
@@ -2,30 +2,40 @@
 #
 # Reverse proxy configuration
 #
-# DSH 反向代理：basic auth + 转发到容器内 dsh 127.0.0.1:3080
+# DSH 反向代理：纯反代（无 basic auth，鉴权在 dsh 自身完成）
 #
-# DSH reverse proxy: basic auth + forwarding to the in-container dsh at 127.0.0.1:3080
+# DSH reverse proxy: pure proxy (no basic auth; authentication is enforced by dsh itself)
+#
+# 0.1.2-rc.1 起鉴权迁回 dsh：浏览器需先用 `?token=<一次性>` 命中 dsh，由 dsh 派发持久 cookie；
+# 旧版本（≤0.1.1-rc.2）的 caddy basic auth 与 dsh 0.1.2-rc.1 的 token/cookie 鉴权重复，
+# 保留 caddy basic_auth 会拦截首次访问根路径的浏览器跳转（用户根本看不到 dsh 的 token URL）。
+# 因此取消 basic auth；DSH_AUTH_USER/PASSWORD/HASH 现在不再被 caddy 使用，但 .env 仍保留以
+# 兼容未来回退到旧版本
+#
+# Since 0.1.2-rc.1, authentication moved into dsh: the browser must first hit dsh with
+# `?token=<one-time>` and receive a persistent cookie. The old caddy basic_auth (≤0.1.1-rc.2)
+# now duplicates dsh 0.1.2-rc.1's token/cookie auth and intercepts the browser's first
+# root-path redirect, hiding dsh's token URL from the user. Drop basic_auth here;
+# DSH_AUTH_USER/PASSWORD/HASH are unused by caddy now but kept in .env for forward/back compat
 #
 # 注意：
 # - 容器内必须监听 0.0.0.0（Docker 端口映射 DNAT 到容器 eth0，bind loopback 会拒接映射流量）
+# - DSH 0.1.2-rc.1 的 web 模式强制 loopback bind（上游显式拒绝 --host 0.0.0.0），
+#   反代是当前唯一让外部访问到 3080 的方式
 # - DSH 特权 API（settings.*/credentials.*）只接受 loopback 来源（防 DNS rebinding），
 #   必须把 Host/Origin 改写为 127.0.0.1:3080 使 dsh 视为本机来源；
 #   Origin 必须与改写后 Host 同源，否则 fence 的 Origin 检查仍 403
-# - bcrypt 哈希含 $ 字符，必须经环境变量注入（{$DSH_AUTH_HASH}），不能直写本文件
 # - http:// 前缀显式声明纯 HTTP 站点，禁用 auto-HTTPS/本地 CA
 #
 # Notes:
 # - Must listen on 0.0.0.0 inside the container (Docker port mapping DNATs to container eth0; binding loopback rejects mapped traffic)
+# - DSH 0.1.2-rc.1's web mode is hard-locked to loopback bind (upstream explicitly rejects
+#   --host 0.0.0.0); reverse-proxy is currently the only path to expose 3080 externally
 # - DSH privileged APIs (settings.*/credentials.*) accept only loopback origins (anti-DNS-rebinding),
 #   Host/Origin must be rewritten to 127.0.0.1:3080 so dsh treats it as a local origin;
 #   Origin must match the rewritten Host, otherwise the fence's Origin check still returns 403
-# - bcrypt hashes contain $, so they must be injected via environment variable ({$DSH_AUTH_HASH}), never written inline
 # - The http:// prefix explicitly declares a plain-HTTP site, disabling auto-HTTPS/local CA
 http://:3081 {
-	basic_auth {
-		{$DSH_AUTH_USER} {$DSH_AUTH_HASH}
-	}
-
 	reverse_proxy 127.0.0.1:3080 {
 		header_up Host 127.0.0.1:3080
 		header_up Origin http://127.0.0.1:3080

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # so agents can compile native modules (e.g. plugin node-pty) at runtime as a fallback.
 # See the runtime stage notes for the trade-off.
 
-ARG DSH_VERSION=0.1.1-rc.2
+ARG DSH_VERSION=0.1.2-rc.1
 
 # Caddy 官方镜像
 # 静态二进制，与平台无关

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ cp .env.example .env    # edit DEEPSEEK_API_KEY (DSH_AUTH_USER/PASSWORD are now 
 docker compose up -d    # pull the latest image and start
 ```
 
+> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时,必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` / `entrypoint.sh 内的 token 抓取后台任务`,仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔(无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
+
 ### Option 2: Build locally
 
 ```bash
 docker compose up -d --build
 # or pin a dsh version:
-docker build --build-arg DSH_VERSION=${DSH_VERSION:-latest} -t dsh-web:latest .
+docker build --build-arg DSH_VERSION=0.1.2-rc.1 -t dsh-web:latest .
 ```
 
 After startup, **read the one-time launch URL** with one of:
@@ -123,7 +125,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends <pkg> \
 
 ## Changing the Password / Resetting Auth
 
-**dsh 0.1.2-rc.1+ (current)**: dsh's persistent cookie is the auth. To reset (e.g. after a suspected leak), delete the data volume's credentials file and recreate the data volume — `docker compose down -v && docker compose up -d`. The next browser visit must use the new one-time token URL (`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`).
+**dsh 0.1.2-rc.1+ (current)**: dsh's persistent cookie is the auth, kept in `./data/.dsh/.credentials.yaml`. To reset after a suspected leak, you **must** rebuild the data volume — `docker compose down -v && docker compose up -d`. The next browser visit uses a new one-time token URL (`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`).
+
+> ⚠️ `down -v` is destructive: it also wipes `./data/.dsh/` (settings, profiles, sessions, agent-installed tools under `~/.x-cmd.root`). There is no lighter reset path — the entrypoint's token-extraction background task is one-shot (`grep -m1`), so a single-file `.credentials.yaml` delete plus container restart will NOT refresh the token URL. If you need to preserve session data, take a backup of `./data/.dsh/` before `down -v` and restore specific subpaths afterwards (e.g. `.dsh/profiles/`, `.dsh/AGENTS.md`).
 
 **Up to dsh 0.1.1 series (rollback)**: edit `DSH_AUTH_PASSWORD` in `.env`, then run `docker compose up -d` (the entrypoint regenerates the hash automatically).
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 > [English](README.md) | [中文](README.zh.md)
 
-Containerized deployment of the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) web client: a single container bundles dsh + Caddy Basic Auth, with configuration and project/session data persisted, and CI automatically pushes GHCR images.
+Containerized deployment of the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) web client: a single container bundles dsh + Caddy (pure reverse proxy, no auth) with configuration and project/session data persisted, and CI automatically pushes GHCR images.
 
 ## Features
 
-- Self-contained single container: dsh (loopback only, inside the container) + Caddy username/password Basic Auth
+- Self-contained single container: dsh (loopback only, inside the container) + Caddy pure reverse proxy (Host/Origin rewritten to loopback for the dsh anti-DNS-rebinding fence)
+- **Authentication since dsh 0.1.2-rc.1**: moved into dsh itself. On first start, dsh prints a one-time `?token=…` URL; the browser exchanges it for a persistent cookie (survives restarts). Caddy basic auth was removed in 0.1.2-rc.1+ (would have intercepted the browser's first redirect and hidden the token URL)
 - Configuration and project/session data persisted: bind mount `./data` → `/home/node` (the whole HOME: settings.yaml, API Key, profiles, sessions, storages, plus agent-installed tools under `~/.x-cmd.root`)
 - Runs as non-root (uid 1000); dsh is not exposed directly
-- Built-in health check: `docker compose ps` shows the real service health (`starting`/`healthy`/`unhealthy`), probing dsh through basic auth with credentials
+- Built-in health check: `docker compose ps` shows the real service health (`starting`/`healthy`/`unhealthy`), exchanging the one-time token for a cookie and probing dsh
 - Pinnable image version: build argument `DSH_VERSION`
 - CI automatically builds and pushes `ghcr.io/xidong-ai/deepseek-harness-web-docker` (latest + date-time-hash tags)
 - A scheduled CI job checks the dsh upstream daily: on a new version it bumps `DSH_VERSION`, builds and smoke-tests the image, pushes to master on success, or opens an Issue on failure (a failed version is not retried automatically while its Issue is open; manual dispatch bypasses the gate)
@@ -24,7 +25,7 @@ Containerized deployment of the [DeepSeek Harness](https://github.com/deepseek-a
 ```bash
 git clone https://github.com/Xidong-AI/deepseek-harness-web-docker
 cd deepseek-harness-web-docker
-cp .env.example .env    # edit DSH_AUTH_USER / DSH_AUTH_PASSWORD / DEEPSEEK_API_KEY
+cp .env.example .env    # edit DEEPSEEK_API_KEY (DSH_AUTH_USER/PASSWORD are now optional, only used on rollback to ≤0.1.1 series)
 docker compose up -d    # pull the latest image and start
 ```
 
@@ -33,21 +34,31 @@ docker compose up -d    # pull the latest image and start
 ```bash
 docker compose up -d --build
 # or pin a dsh version:
-docker build --build-arg DSH_VERSION=0.1.1-rc.2 -t dsh-web:latest .
+docker build --build-arg DSH_VERSION=${DSH_VERSION:-latest} -t dsh-web:latest .
 ```
 
-After startup, open `http://<host>:3080` in a browser (the port is controlled by `DSH_WEB_PORT` in `.env`) and enter the Basic Auth username and password.
+After startup, **read the one-time launch URL** with one of:
+
+```bash
+docker compose logs dsh-web | grep 'dsh web:'         # dsh prints it on startup
+# or
+docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt
+```
+
+Then open the printed URL (e.g. `http://<host>:3080/?token=…`) in a browser. The browser is redirected (HTTP 303) to `/` with a persistent cookie set; subsequent visits work without the token. The cookie lives in `./data/.dsh/.credentials.yaml` and survives container restarts (re-roll the token URL each time you recreate the data volume from scratch). The port is `DSH_WEB_PORT` (default 3080).
+
+> **Up to dsh 0.1.1 series** (rollback): open `http://<host>:3080` and use Caddy basic auth (the `DSH_AUTH_USER` / `DSH_AUTH_PASSWORD` in `.env`).
 
 ## Environment Variables (.env)
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `DSH_AUTH_USER` | Yes | `admin` | Basic Auth username |
-| `DSH_AUTH_PASSWORD` | Yes | None | Basic Auth plaintext password (bcrypt hash generated automatically at container startup) |
+| `DSH_AUTH_USER` | No (since 0.1.2-rc.1) | `admin` | Was: Basic Auth username. Now kept only for rollback to ≤0.1.1 series; ignored on 0.1.2-rc.1+ |
+| `DSH_AUTH_PASSWORD` | No (since 0.1.2-rc.1) | None | Was: Basic Auth plaintext password (bcrypt hash auto-generated). Now kept only for rollback to ≤0.1.1 series |
 | `DEEPSEEK_API_KEY` | Yes | None | DeepSeek API Key (referenced by the provider via apiKeyEnv) |
 | `DSH_WEB_PORT` | No | `3080` | Host port exposed to the outside (change it when it conflicts with an existing service) |
 | `DSH_TRUSTED_HOSTS` | No | Empty | Comma-separated extra trusted hosts, injected into the profile's `cordis.patch.yml` (only when the file is absent or still the empty template; user-maintained files are skipped — edit the file directly); by default Caddy rewrites Host/Origin to loopback, which covers normal access |
-| `DSH_VERSION` | No (build-time) | `0.1.1-rc.2` | dsh version; rebuild with `--build` after changing it |
+| `DSH_VERSION` | No (build-time) | Upstream latest | dsh version; rebuild with `--build` after changing it |
 
 > `.env` contains passwords and the API Key — never commit it to the repository.
 
@@ -110,9 +121,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends <pkg> \
  && rm -rf /var/lib/apt/lists/*
 ```
 
-## Changing the Password
+## Changing the Password / Resetting Auth
 
-Edit `DSH_AUTH_PASSWORD` in `.env`, then run `docker compose up -d` (the entrypoint regenerates the hash automatically).
+**dsh 0.1.2-rc.1+ (current)**: dsh's persistent cookie is the auth. To reset (e.g. after a suspected leak), delete the data volume's credentials file and recreate the data volume — `docker compose down -v && docker compose up -d`. The next browser visit must use the new one-time token URL (`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`).
+
+**Up to dsh 0.1.1 series (rollback)**: edit `DSH_AUTH_PASSWORD` in `.env`, then run `docker compose up -d` (the entrypoint regenerates the hash automatically).
 
 ## Acknowledgements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,12 +29,14 @@ cp .env.example .env    # 编辑 DEEPSEEK_API_KEY（DSH_AUTH_USER/PASSWORD 自 0
 docker compose up -d    # 拉取 latest 镜像并启动
 ```
 
+> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时,必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` 内的 token 抓取后台任务,仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔(无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
+
 ### 方式二：本地构建
 
 ```bash
 docker compose up -d --build
 # 或指定 dsh 版本：
-docker build --build-arg DSH_VERSION=${DSH_VERSION:-latest} -t dsh-web:latest .
+docker build --build-arg DSH_VERSION=0.1.2-rc.1 -t dsh-web:latest .
 ```
 
 启动后**先取一次性启动 URL**，任选一种方式：
@@ -123,7 +125,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends <pkg> \
 
 ## 修改密码 / 重置鉴权
 
-**dsh 0.1.2-rc.1+（当前）**：dsh 持久 cookie 是鉴权载体。怀疑泄露需重置时，删除数据卷的凭据文件并重建数据卷 — `docker compose down -v && docker compose up -d`。下次浏览器访问需用新的一次性 token URL（`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`）。
+**dsh 0.1.2-rc.1+（当前）**：dsh 持久 cookie 是鉴权载体，存于 `./data/.dsh/.credentials.yaml`。怀疑泄露需重置时，**必须**重建数据卷 — `docker compose down -v && docker compose up -d`。下次浏览器访问需用新的一次性 token URL（`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`）。
+
+> ⚠️ `down -v` 是破坏性操作：会同时清空 `./data/.dsh/`（settings、profiles、sessions，及 agent 自装工具 `~/.x-cmd.root`）。目前没有更轻量的重置路径 — entrypoint 的 token 抓取后台任务是单次执行（`grep -m1`），仅删 `.credentials.yaml` 后重启容器**不会**重抓 token URL。如需保留会话数据，先备份 `./data/.dsh/`，重置后按需恢复子路径（如 `.dsh/profiles/`、`.dsh/AGENTS.md`）。
 
 **dsh ≤0.1.1 系列（回退）**：编辑 `.env` 的 `DSH_AUTH_PASSWORD`，然后 `docker compose up -d`（entrypoint 自动重新生成哈希）。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,14 +4,15 @@
 
 > [English](README.md) | [中文](README.zh.md)
 
-容器化部署 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）Web 客户端：单容器内含 dsh + Caddy basic auth，配置与项目/会话数据持久化，CI 自动推送 GHCR 镜像。
+容器化部署 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（dsh）Web 客户端：单容器内含 dsh + Caddy 纯反代，配置与项目/会话数据持久化，CI 自动推送 GHCR 镜像。
 
 ## 特性
 
-- 单容器自包含：dsh（仅容器内 loopback）+ Caddy 基础用户名密码认证（basic auth）
+- 单容器自包含：dsh（仅容器内 loopback）+ Caddy 纯反代（无鉴权，Host/Origin 改写为 loopback 配合 dsh 防 DNS rebinding 的 fence）
+- **dsh 0.1.2-rc.1+ 鉴权**：迁回 dsh 自身。dsh 启动时打印一次性 `?token=…` URL，浏览器首次访问该 URL 后 303 跳转并 Set-Cookie，cookie 持久化在数据卷（容器重启后仍有效）。Caddy basic auth 自 0.1.2-rc.1 起移除（旧版会拦截首次重定向、把 dsh 的 token URL 藏住，浏览器根本拿不到）
 - 配置与项目/会话数据持久化：bind mount `./data` → `/home/node`（整个 HOME：settings.yaml、API Key、profiles、sessions、storages，及 agent 自装工具 `~/.x-cmd.root`）
 - 非 root 运行（uid 1000），dsh 不直接对外暴露
-- 内置健康检查：`docker compose ps` 直接可见服务真实健康状态（带凭据穿透 basic auth 探测 dsh 响应，`starting`/`healthy`/`unhealthy`）
+- 内置健康检查：`docker compose ps` 直接可见服务真实健康状态（抓 dsh 一次性 token 换 cookie 后探测 dsh 响应，`starting`/`healthy`/`unhealthy`）
 - 镜像版本可 pin：构建参数 `DSH_VERSION`
 - CI 自动构建并推送 `ghcr.io/xidong-ai/deepseek-harness-web-docker`（latest + 日期时间 - 哈希 tag）
 - 定时任务每日检查 dsh 上游：有新版本自动提升 `DSH_VERSION`、构建并冒烟测试，通过则推送 master 并钩住触发 GHCR 发布，失败则创建 Issue（存在同版本未关闭 Issue 时不再自动重试，可手动触发强制重试）
@@ -24,7 +25,7 @@
 ```bash
 git clone https://github.com/Xidong-AI/deepseek-harness-web-docker
 cd deepseek-harness-web-docker
-cp .env.example .env    # 编辑 DSH_AUTH_USER / DSH_AUTH_PASSWORD / DEEPSEEK_API_KEY
+cp .env.example .env    # 编辑 DEEPSEEK_API_KEY（DSH_AUTH_USER/PASSWORD 自 0.1.2-rc.1 起可选，仅回退到 ≤0.1.1 系列时需要）
 docker compose up -d    # 拉取 latest 镜像并启动
 ```
 
@@ -33,21 +34,31 @@ docker compose up -d    # 拉取 latest 镜像并启动
 ```bash
 docker compose up -d --build
 # 或指定 dsh 版本：
-docker build --build-arg DSH_VERSION=0.1.1-rc.2 -t dsh-web:latest .
+docker build --build-arg DSH_VERSION=${DSH_VERSION:-latest} -t dsh-web:latest .
 ```
 
-启动后浏览器访问 `http://<主机>:3080`（端口由 `.env` 的 `DSH_WEB_PORT` 控制），输入 basic auth 用户名密码。
+启动后**先取一次性启动 URL**，任选一种方式：
+
+```bash
+docker compose logs dsh-web | grep 'dsh web:'         # dsh 启动时打印
+# 或
+docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt
+```
+
+把打印的 URL（如 `http://<主机>:3080/?token=…`）粘到浏览器访问。浏览器被 303 重定向到 `/` 并写入持久 cookie；之后访问不再需要 token。cookie 存于 `./data/.dsh/.credentials.yaml`，容器重启仍有效（重新创建数据卷才需重抓 token URL）。外部端口由 `DSH_WEB_PORT` 控制（默认 3080）。
+
+> **dsh ≤0.1.1 系列（回退情况）**：浏览器直接访问 `http://<主机>:3080`，输入 Caddy basic auth 用户名密码（`.env` 里的 `DSH_AUTH_USER` / `DSH_AUTH_PASSWORD`）。
 
 ## 环境变量（.env）
 
 | 变量 | 必填 | 默认 | 说明 |
 | --- | --- | --- | --- |
-| `DSH_AUTH_USER` | 是 | `admin` | basic auth 用户名 |
-| `DSH_AUTH_PASSWORD` | 是 | 无 | basic auth 明文密码（容器启动时自动生成 bcrypt 哈希） |
+| `DSH_AUTH_USER` | 否（自 0.1.2-rc.1） | `admin` | 旧版 basic auth 用户名；0.1.2-rc.1+ 已忽略，仅作回退兼容位 |
+| `DSH_AUTH_PASSWORD` | 否（自 0.1.2-rc.1） | 无 | 旧版 basic auth 明文密码（容器启动时自动生成 bcrypt 哈希）；0.1.2-rc.1+ 已忽略，仅作回退兼容位 |
 | `DEEPSEEK_API_KEY` | 是 | 无 | DeepSeek API Key（provider 经 apiKeyEnv 引用） |
 | `DSH_WEB_PORT` | 否 | `3080` | 宿主机对外端口（与已有服务冲突时修改） |
 | `DSH_TRUSTED_HOSTS` | 否 | 空 | 逗号分隔的额外受信 Host，注入 profile 的 `cordis.patch.yml`（仅当该文件不存在或仍为空模板时自动注入；已维护则跳过，请直接编辑该文件）；默认靠 Caddy 改写 Host/Origin 为 loopback 已覆盖常规访问 |
-| `DSH_VERSION` | 否（构建期） | `0.1.1-rc.2` | dsh 版本，修改后需 `--build` 重建 |
+| `DSH_VERSION` | 否（构建期） | 上游最新 | dsh 版本，修改后需 `--build` 重建 |
 
 > `.env` 含密码与 API Key，禁止提交入库。
 
@@ -110,9 +121,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends <pkg> \
  && rm -rf /var/lib/apt/lists/*
 ```
 
-## 修改密码
+## 修改密码 / 重置鉴权
 
-编辑 `.env` 的 `DSH_AUTH_PASSWORD`，然后 `docker compose up -d`（entrypoint 自动重新生成哈希）。
+**dsh 0.1.2-rc.1+（当前）**：dsh 持久 cookie 是鉴权载体。怀疑泄露需重置时，删除数据卷的凭据文件并重建数据卷 — `docker compose down -v && docker compose up -d`。下次浏览器访问需用新的一次性 token URL（`docker exec dsh-web cat /home/node/.dsh/web-launch-url.txt`）。
+
+**dsh ≤0.1.1 系列（回退）**：编辑 `.env` 的 `DSH_AUTH_PASSWORD`，然后 `docker compose up -d`（entrypoint 自动重新生成哈希）。
 
 ## 鸣谢
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,18 +23,24 @@ services:
     env_file: .env
     environment:
       - HOME=/home/node
-    # 健康检查：带凭据穿透 basic auth 请求 Caddy 反代，仅 200（dsh 真实响应）算健康；
-    # 401 是 Caddy 层拒绝、502 是 dsh 未就绪，均不算健康。
-    # $$ 转义为字面 $，运行时在容器内展开为 env_file 注入的凭据。
-    # start_period 覆盖 dsh 首启初始化（bundles 安装可能 1-2 分钟）。
+    # 健康检查：跟冒烟脚本同一条路径——抓 dsh 启动的一次性 token URL，用 token 换 cookie，
+    # 再带 cookie 测根路径 200 算健康。
+    # 自 0.1.2-rc.1 起 caddy 不再 basic auth（鉴权迁回 dsh 自身），DSH_AUTH_USER/PASSWORD 不再使用。
+    # 早于 0.1.2-rc.1 的版本没有 token 机制，healthcheck 走 token 流程会失败（容器不健康）——
+    # 所以这个 healthcheck 默认是为 0.1.2-rc.1+ 设计的；回退到更早版本时需要改 healthcheck
+    # start_period 覆盖 dsh 首启初始化（bundles 安装可能 1-2 分钟）
     #
-    # Health check: request through Caddy with credentials; only 200 (dsh actually responding)
-    # counts as healthy — 401 is rejected at the Caddy layer and 502 means dsh is not up yet.
-    # $$ escapes to a literal $, expanded at runtime to the credentials injected via env_file.
+    # Health check follows the smoke-test path: read dsh's one-time token URL, exchange it
+    # for a cookie via 303, then GET / with the cookie and expect 200.
+    # 0.1.2-rc.1+ removed caddy basic_auth (auth moved into dsh itself), so DSH_AUTH_USER/PASSWORD
+    # are unused. Earlier versions have no token mechanism — the healthcheck would fail, so
+    # rollbacks must update it too.
     # start_period covers dsh's first-run init (bundle installation may take 1-2 minutes).
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -u \"$${DSH_AUTH_USER}:$${DSH_AUTH_PASSWORD}\" http://127.0.0.1:3081/ >/dev/null 2>&1 || exit 1"]
+      test:
+        - "CMD-SHELL"
+        - "set -e; url=$$(cat /home/node/.dsh/web-launch-url.txt 2>/dev/null || true); [ -n \"$$url\" ] || exit 1; cookie=$$(mktemp); code=$$(curl -sS -c \"$$cookie\" -o /dev/null -w '%{http_code}' \"$$url\"); [ \"$$code\" = \"303\" ] || { rm -f \"$$cookie\"; exit 1; }; code=$$(curl -sS -b \"$$cookie\" -o /dev/null -w '%{http_code}' http://127.0.0.1:3081/); rm -f \"$$cookie\"; [ \"$$code\" = \"200\" ]"
       interval: 30s
-      timeout: 5s
+      timeout: 10s
       retries: 3
       start_period: 120s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       args:
-        DSH_VERSION: ${DSH_VERSION:-0.1.1-rc.2}
+        DSH_VERSION: ${DSH_VERSION:-0.1.2-rc.1}
     container_name: dsh-web
     restart: unless-stopped
     ports:
@@ -25,14 +25,14 @@ services:
       - HOME=/home/node
     # 健康检查：跟冒烟脚本同一条路径——抓 dsh 启动的一次性 token URL，用 token 换 cookie，
     # 再带 cookie 测根路径 200 算健康。
-    # 自 0.1.2-rc.1 起 caddy 不再 basic auth（鉴权迁回 dsh 自身），DSH_AUTH_USER/PASSWORD 不再使用。
-    # 早于 0.1.2-rc.1 的版本没有 token 机制，healthcheck 走 token 流程会失败（容器不健康）——
-    # 所以这个 healthcheck 默认是为 0.1.2-rc.1+ 设计的；回退到更早版本时需要改 healthcheck
+    # 自 0.1.2 系列起 caddy 不再 basic auth（鉴权迁回 dsh 自身），DSH_AUTH_USER/PASSWORD 不再使用。
+    # 早于 0.1.2 的版本没有 token 机制，healthcheck 走 token 流程会失败（容器不健康）——
+    # 所以这个 healthcheck 默认是为 0.1.2+ 设计的；回退到更早版本时需要改 healthcheck
     # start_period 覆盖 dsh 首启初始化（bundles 安装可能 1-2 分钟）
     #
     # Health check follows the smoke-test path: read dsh's one-time token URL, exchange it
     # for a cookie via 303, then GET / with the cookie and expect 200.
-    # 0.1.2-rc.1+ removed caddy basic_auth (auth moved into dsh itself), so DSH_AUTH_USER/PASSWORD
+    # 0.1.2 series removed caddy basic_auth (auth moved into dsh itself), so DSH_AUTH_USER/PASSWORD
     # are unused. Earlier versions have no token mechanism — the healthcheck would fail, so
     # rollbacks must update it too.
     # start_period covers dsh's first-run init (bundle installation may take 1-2 minutes).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,25 +21,30 @@ log() { echo "[entrypoint] $*"; }
 # so a rollback to ≤0.1.1-rc.2 still works without .env surgery
 : "${DEEPSEEK_API_KEY:?必须设置 DEEPSEEK_API_KEY（.env）}"
 
-# ---- basic auth：明文密码 → bcrypt 哈希（注入 Caddyfile 环境变量，0.1.2-rc.1+ 无害保留）----
-# 0.1.2-rc.1 起 caddy 不再 basic auth（见 Caddyfile 注释），但 Caddyfile 仍期望 DSH_AUTH_HASH
-# 占位符存在以保格式正确；未提供 DSH_AUTH_PASSWORD 时写一个不会匹配的占位值
-# （Caddy 仍解析，但任何 basic auth 尝试必然 401 失败，相当于关闭）
+# ---- basic auth：明文密码 → bcrypt 哈希（为回退兼容保留，0.1.2-rc.1+ 不被任何消费者使用）----
+# 0.1.2-rc.1+ 的 Caddyfile 已不引用 {$DSH_AUTH_HASH}（Caddyfile 块本身不出现该占位符，
+# 见 PR #7 改动）。本块在当前 image 是无消费者的导出，仅在回退到 ≤0.1.1-rc.2 流程时
+# 才被旧 Caddyfile 使用——回退需要从 git history 拉回旧 Caddyfile（basic_auth 块 + 占位符）
+# 一起恢复，因此 DSH_AUTH_HASH 仍必须在此处派生（否则回退到旧 image 时 caddy 启动报错）。
+# 视为「回退兼容位的准备代码」而非「当前生效的鉴权逻辑」——删它会破坏回退路径
 #
-# ---- Basic auth: plaintext password → bcrypt hash (injected into Caddyfile env vars, harmless since 0.1.2-rc.1) ----
-# Caddy 0.1.2-rc.1+ doesn't basic-auth (see Caddyfile), but the Caddyfile still references
-# {$DSH_AUTH_HASH} for parser compatibility. When DSH_AUTH_PASSWORD is unset, substitute a
-# placeholder that cannot match any input (bcrypt-formatted dummy) so any stray basic-auth
-# probe is deterministically 401 — effectively disabled
+# ---- Basic auth hash: retained for rollback compatibility, no current consumer ----
+# The 0.1.2-rc.1+ Caddyfile does not reference {$DSH_AUTH_HASH}. This block is a no-consumer
+# export in the current image; it only feeds the old Caddyfile (≤0.1.1-rc.2) on rollback,
+# which requires restoring the basic_auth block from git history. Delete this block only
+# if rollback support to ≤0.1.1-rc.2 is also dropped.
 if [ -n "${DSH_AUTH_PASSWORD:-}" ]; then
   DSH_AUTH_HASH="$(caddy hash-password --plaintext "$DSH_AUTH_PASSWORD" | tail -n 1)"
 else
-  # 长度匹配 bcrypt 输出但内容不匹配任何密码（让 caddy 解析通过，验证永远失败）
+  # 占位 bcrypt 哈希：格式合法（$2a$10$... + 22 字符 salt）但内容不匹配任何输入。
+  # 当前 image 不消费此变量；若被误用到旧 Caddyfile，任何 basic auth 试探必 401，等效关闭
   #
-  # Matches bcrypt output length but never matches any input (lets caddy parse, validation always fails)
+  # Placeholder bcrypt hash: well-formed (passes parser) but never matches any input.
+  # Current image has no consumer; if accidentally used by an old Caddyfile, deterministically
+  # 401s any basic-auth probe (effectively closed)
   # shellcheck disable=SC2016 # 单引号是有意的：占位 bcrypt 哈希（$2a$10$...）需要字面 $ 字符
   DSH_AUTH_HASH='$2a$10$invalidplaceholderhashthatnevermatches0000000000000'
-  log "DSH_AUTH_PASSWORD 未设置：caddy basic auth 已被 0.1.2-rc.1 移除，此处仅占位"
+  log "DSH_AUTH_PASSWORD 未设置：DSH_AUTH_HASH 写占位值（回退兼容位；当前 image 不使用）"
 fi
 export DSH_AUTH_HASH
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,24 +1,46 @@
 #!/usr/bin/env bash
 # 容器入口脚本
-# dsh-web 容器入口：校验必需变量 → 生成 bcrypt → 首启初始化数据卷 → 启动 supervisord
+# dsh-web 容器入口：校验必需变量 → 可选 bcrypt → 首启初始化数据卷 → 启动 supervisord
+# dsh 启动后，后台抓取 0.1.2-rc.1 的一次性 token URL 写到 $DHS_HOME/web-launch-url.txt
 #
 # Container Entrypoint Script
-# dsh-web container entrypoint: validate required env vars → generate bcrypt → initialize the data volume on first run → start supervisord
+# dsh-web container entrypoint: validate required env vars → optional bcrypt → initialize the data volume on first run → start supervisord
+# Once dsh starts, a background tail greps the 0.1.2-rc.1 one-time token URL and persists
+# it to $DHS_HOME/web-launch-url.txt so operators can read it (see the post-supervisord block)
 set -euo pipefail
 
 log() { echo "[entrypoint] $*"; }
 
 # ---- 必需变量校验 ----
+# DEEPSEEK_API_KEY 是 dsh 运行时必需；DSH_AUTH_USER / DSH_AUTH_PASSWORD 自 0.1.2-rc.1
+# 不再被 caddy 使用（鉴权迁回 dsh 自身），改为可选保留以便回退到 ≤0.1.1-rc.2 时继续生效
 #
 # ---- Required variable validation ----
-: "${DSH_AUTH_USER:?必须设置 DSH_AUTH_USER（.env）}"
-: "${DSH_AUTH_PASSWORD:?必须设置 DSH_AUTH_PASSWORD（.env）}"
+# DEEPSEEK_API_KEY is required by dsh at runtime. DSH_AUTH_USER / DSH_AUTH_PASSWORD are
+# no longer used by caddy since 0.1.2-rc.1 (auth moved into dsh itself) but kept optional
+# so a rollback to ≤0.1.1-rc.2 still works without .env surgery
 : "${DEEPSEEK_API_KEY:?必须设置 DEEPSEEK_API_KEY（.env）}"
 
-# ---- basic auth：明文密码 → bcrypt 哈希（注入 Caddyfile 环境变量）----
+# ---- basic auth：明文密码 → bcrypt 哈希（注入 Caddyfile 环境变量，0.1.2-rc.1+ 无害保留）----
+# 0.1.2-rc.1 起 caddy 不再 basic auth（见 Caddyfile 注释），但 Caddyfile 仍期望 DSH_AUTH_HASH
+# 占位符存在以保格式正确；未提供 DSH_AUTH_PASSWORD 时写一个不会匹配的占位值
+# （Caddy 仍解析，但任何 basic auth 尝试必然 401 失败，相当于关闭）
 #
-# ---- Basic auth: plaintext password → bcrypt hash (injected into Caddyfile env vars) ----
-DSH_AUTH_HASH="$(caddy hash-password --plaintext "$DSH_AUTH_PASSWORD" | tail -n 1)"
+# ---- Basic auth: plaintext password → bcrypt hash (injected into Caddyfile env vars, harmless since 0.1.2-rc.1) ----
+# Caddy 0.1.2-rc.1+ doesn't basic-auth (see Caddyfile), but the Caddyfile still references
+# {$DSH_AUTH_HASH} for parser compatibility. When DSH_AUTH_PASSWORD is unset, substitute a
+# placeholder that cannot match any input (bcrypt-formatted dummy) so any stray basic-auth
+# probe is deterministically 401 — effectively disabled
+if [ -n "${DSH_AUTH_PASSWORD:-}" ]; then
+  DSH_AUTH_HASH="$(caddy hash-password --plaintext "$DSH_AUTH_PASSWORD" | tail -n 1)"
+else
+  # 长度匹配 bcrypt 输出但内容不匹配任何密码（让 caddy 解析通过，验证永远失败）
+  #
+  # Matches bcrypt output length but never matches any input (lets caddy parse, validation always fails)
+  # shellcheck disable=SC2016 # 单引号是有意的：占位 bcrypt 哈希（$2a$10$...）需要字面 $ 字符
+  DSH_AUTH_HASH='$2a$10$invalidplaceholderhashthatnevermatches0000000000000'
+  log "DSH_AUTH_PASSWORD 未设置：caddy basic auth 已被 0.1.2-rc.1 移除，此处仅占位"
+fi
 export DSH_AUTH_HASH
 
 # ---- 数据卷首启初始化（/home/node/.dsh，node 用户为 uid 1000）----
@@ -153,8 +175,46 @@ EOF
   log "x-cmd 就绪（已启用包：$pkg_list）"
 fi
 
+# ---- dsh 0.1.2-rc.1 一次性 token 提取后台任务 ----
+# dsh 启动时打印 `dsh web: http://127.0.0.1:3080/?token=XXX`，但因 dsh 强制 loopback bind
+# （上游拒 --host 0.0.0.0），外部浏览器拿不到这个 URL；supervisord 把 dsh 输出 tee 到
+# $DHS_HOME/web-server.log（见 supervisord.conf），这里起一个后台 tail 任务：
+# 1) 等文件出现（dsh 可能要 30+ 秒才就绪）
+# 2) grep 一次 ?token=… 并写入 $DHS_HOME/web-launch-url.txt
+# 3) 写完后退出（任务只做一次：首启一次性 token 即可让浏览器完成 cookie 交换，
+#    后续重启 cookie 已持久化在 $DHS_HOME/.credentials.yaml，无需重抓）
+#
+# ---- Background task: extract dsh 0.1.2-rc.1's one-time token URL ----
+# dsh prints `dsh web: http://127.0.0.1:3080/?token=XXX` on startup, but since dsh 0.1.2-rc.1
+# hard-binds to loopback (upstream refuses --host 0.0.0.0), external browsers can't see it.
+# supervisord tees dsh's output to $DHS_HOME/web-server.log; we spawn a background tail that
+# (1) waits for the file (dsh may take 30+ s), (2) greps the token URL once, (3) writes it
+# to $DHS_HOME/web-launch-url.txt, then exits. One-time is enough: the first exchange
+# persists a cookie in $DHS_HOME/.credentials.yaml that survives restarts.
+# 0.1.1-rc.2 doesn't print this URL, so on older dsh the file stays empty — harmless.
+WEB_LOG="$DHS_HOME/web-server.log"
+WEB_URL_FILE="$DHS_HOME/web-launch-url.txt"
+touch "$WEB_LOG"  # 让 tail -F 立即可订阅（dsh 启动后追加）
+(
+  # 在子 shell 中等 + 抓 + 写 + 退出；不影响 entrypoint 主体
+  #
+  # In a subshell: wait + grep + write + exit. Doesn't block the main entrypoint
+  set +e  # 关闭子 shell 严格模式：grep 没匹配时正常返回非零
+  url="$(tail -F -n 0 -- "$WEB_LOG" 2>/dev/null | grep -m1 -oE 'http://127\.0\.0\.1:[0-9]+/\?token=[A-Za-z0-9_-]{43}')"
+  if [ -n "${url:-}" ]; then
+    printf '%s\n' "$url" > "$WEB_URL_FILE"
+    chmod 644 "$WEB_URL_FILE"
+    log "已抓取 dsh 启动 URL: $url"
+    log "  写入 $WEB_URL_FILE（外部用户首次访问需先访问该 URL 拿 cookie）"
+  else
+    log "未在 dsh 启动日志中捕获到 ?token= URL（可能 dsh <0.1.2-rc.1，无 token 鉴权）"
+  fi
+) &
+disown || true
+log "dsh token 提取后台任务已启动（pid=$!），结果写入 $WEB_URL_FILE"
+
 # ---- 启动 supervisord（dsh + caddy）----
 #
 # ---- Start supervisord (dsh + caddy) ----
-log "启动 supervisord（DSH_AUTH_USER=$DSH_AUTH_USER，对外端口由 compose 映射）"
+log "启动 supervisord（DSH_AUTH_USER=${DSH_AUTH_USER:-<unset,0.1.2-rc.1+ 不再使用>}，对外端口由 compose 映射）"
 exec supervisord -c /etc/supervisor/conf.d/dsh.conf

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -20,6 +20,10 @@ cleanup() {
   # first line, swallow internal cleanup failures into a warn, and `return` it so it
   # propagates to Actions as the real failure rather than a silent success
   local rc=$?
+  # cookie 文件：0.1.2-rc.1+ 鉴权流程创建的临时 cookie，与 SMOKE_HOME 一起删即可
+  # (cookie jar 在 SMOKE_PARENT 下，独立 mktemp 但跟着 SMOKE_HOME 的 rm -rf 也走
+  # 因为 mktemp -p 选了 SMOKE_PARENT；不过保险起见显式删一次)
+  [ -n "${SMOKE_COOKIE:-}" ] && [ -f "$SMOKE_COOKIE" ] && rm -f "$SMOKE_COOKIE" 2>/dev/null || true
   docker rm -f "$CID" >/dev/null 2>&1 || true
   if [ -n "${SMOKE_HOME:-}" ] && [ -d "$SMOKE_HOME" ]; then
     # 先放宽权限再递归删：容器内 uid 1000 (node) 写下的子文件可能只对本人可写，
@@ -78,46 +82,117 @@ PORT="$(docker port "$CID" 3081 | head -n1 | sed 's/.*://')"
 echo "    容器 $CID 已启动，映射端口 $PORT"
 
 echo "==> 等待服务就绪（最多 240s）"
-# 仅 200 视为就绪：502（Caddy 已起但 dsh 未就绪）与 000（未监听）都继续等；
-# 401 是 Caddy basic auth 层拒绝、不经过反代，也不能代表 dsh 就绪
+# 等三件事之一：1) 200（≤0.1.1-rc.2 旧 caddy basic auth 通过）2) 401（0.1.2-rc.1+ 路径，
+# caddy 活，dsh 鉴权拒绝无 token）3) entrypoint 后台抓到的 web-launch-url.txt 出现
+# （dsh 启动后 5-30 秒内）。任一即就绪。502/000 继续等
 #
-# Only 200 means ready: 502 (Caddy up but dsh not yet) and 000 (not listening) keep waiting;
-# 401 is rejected at the Caddy basic-auth layer without touching the proxy, so it proves nothing
-#
-# 阈值从 120s 提到 240s：0.1.2-rc.1 在 GitHub Actions runner 上首启需 ~150s
-# (x-cmd 80MB 下载 + dsh web bundles 懒加载)，120s 反复误报上游慢。240s 留一倍余量，
-# 真挂的场景仍会超时但能区分「慢」vs「挂」
-#
-# Threshold raised 120s→240s: dsh 0.1.2-rc.1 first boot on GitHub Actions runner
-# takes ~150s (80MB x-cmd download + dsh web bundles lazy load). 120s kept misfiring
-# on upstream slowness; 240s leaves 1× headroom while still failing on real hangs
+# Wait for any of: 1) 200 (≤0.1.1-rc.2 old caddy basic-auth) 2) 401 (0.1.2-rc.1+,
+# caddy alive, dsh rejects no-token) 3) web-launch-url.txt written (5-30 s after dsh).
+# Any one means "ready". 502/000 keep waiting.
 READY=0
 LAST_CODE=000
+URL_FILE="$SMOKE_HOME/.dsh/web-launch-url.txt"
 START_TS="$(date +%s)"
 for _ in $(seq 1 120); do
-  CODE="$(curl -s -u admin:smoketest -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/" || true)"
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/" || true)"
   LAST_CODE="$CODE"
-  if [ "$CODE" = "200" ]; then READY=1; break; fi
+  if [ "$CODE" = "200" ] || [ "$CODE" = "401" ] || [ -s "$URL_FILE" ]; then
+    READY=1; break
+  fi
   sleep 2
 done
 if [ "$READY" != 1 ]; then
   ELAPSED=$(( $(date +%s) - START_TS ))
-  echo "错误：服务 ${ELAPSED}s 内未就绪（最后一次 HTTP code=$LAST_CODE）" >&2
+  echo "错误：服务 ${ELAPSED}s 内 Caddy 仍未监听（最后一次 HTTP code=$LAST_CODE，token 文件未出现）" >&2
+  echo "  （502/000 = 仍在启动；持续 502 = 上游启动慢/挂）" >&2
   docker logs "$CID" 2>&1 | tail -30 >&2
   exit 1
 fi
 
-echo "==> basic auth：无凭据应 401"
-CODE="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
-[ "$CODE" = "401" ] || { echo "错误：期望 401 实际 $CODE" >&2; exit 1; }
+# 版本分叉：检测 dsh 版本决定鉴权流程
+# dsh <0.1.2-rc.1 (e.g. 0.1.1-rc.2)：用 caddy basic auth（DSH_AUTH_USER/PASSWORD）
+# dsh >=0.1.2-rc.1：用 token+cookie（dsh 0.1.2-rc.1 引入的一次性 token + 持久 cookie，
+#   caddy 0.1.2-rc.1+ 不再 basic auth，DSH_AUTH_USER/PASSWORD 保留为兼容位但 caddy 不用）
+#
+# Version fork: pick the auth flow by dsh version
+# dsh <0.1.2-rc.1 (e.g. 0.1.1-rc.2): caddy basic auth
+# dsh >=0.1.2-rc.1: token + cookie (dsh 0.1.2-rc.1 one-time token + persistent cookie;
+#   caddy 0.1.2-rc.1+ no longer basic-auths, DSH_AUTH_USER/PASSWORD are kept for compat)
+case "$VERSION" in
+  0.1.0-*|0.1.1-*)
+    # 旧版鉴权：basic auth（dsh ≤0.1.1-rc.2）
+    echo "==> 旧版鉴权：basic auth（dsh $VERSION）"
+    echo "==> basic auth：无凭据应 401"
+    CODE="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
+    [ "$CODE" = "401" ] || { echo "错误：期望 401 实际 $CODE" >&2; exit 1; }
 
-echo "==> basic auth：带凭据应 200"
-CODE="$(curl -s -u admin:smoketest -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
-[ "$CODE" = "200" ] || { echo "错误：期望 200 实际 $CODE" >&2; exit 1; }
+    echo "==> basic auth：带凭据应 200"
+    CODE="$(curl -s -u admin:smoketest -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
+    [ "$CODE" = "200" ] || {
+      echo "错误：带 admin:smoketest 凭据应返 200，实际 $CODE" >&2
+      docker logs "$CID" 2>&1 | tail -30 >&2
+      exit 1
+    }
+    # basic auth 路径：API fence 步骤用 basic auth
+    AUTH_FLAGS=(-u admin:smoketest)
+    ;;
+  *)
+    # 新版鉴权：token + cookie（dsh ≥0.1.2-rc.1）
+    echo "==> 新版鉴权：token + cookie（dsh $VERSION）"
+    # 等 token URL 文件（entrypoint 后台任务写入，dsh 启动后 1-30 秒内出现）
+    # Wait for token URL file (entrypoint's background task writes it 1-30 s after dsh starts)
+    for _ in $(seq 1 60); do
+      [ -s "$URL_FILE" ] && break
+      sleep 1
+    done
+    if [ ! -s "$URL_FILE" ]; then
+      echo "错误：dsh 启动后 60s 内未在 $URL_FILE 捕获到 ?token= URL" >&2
+      echo "--- 容器 web-server.log 后 30 行（dsh 启动日志 tee）---" >&2
+      tail -30 "$SMOKE_HOME/.dsh/web-server.log" >&2 || true
+      docker logs "$CID" 2>&1 | tail -30 >&2
+      exit 1
+    fi
+    LAUNCH_URL="$(cat "$URL_FILE")"
+    echo "    抓取到 dsh 启动 URL: $LAUNCH_URL"
+    # 一次性 token 换持久 cookie：GET ?token=XXX → 303 + Set-Cookie
+    # Exchange one-time token for persistent cookie: GET ?token=XXX → 303 + Set-Cookie
+    SMOKE_COOKIE="$(mktemp -p "$SMOKE_PARENT" smoke-cookie-XXXXXX)"
+    CODE="$(curl -sS -c "$SMOKE_COOKIE" -o /dev/null -w '%{http_code}' "$LAUNCH_URL" || true)"
+    if [ "$CODE" != "303" ]; then
+      echo "错误：带 token 访问应返 303 重定向，实际 $CODE" >&2
+      cat "$SMOKE_COOKIE" >&2 || true
+      docker logs "$CID" 2>&1 | tail -20 >&2
+      exit 1
+    fi
+    if ! grep -q "dsh" "$SMOKE_COOKIE" 2>/dev/null; then
+      echo "错误：token 交换后未拿到 Set-Cookie（dsh 应发 HttpOnly cookie）" >&2
+      cat "$SMOKE_COOKIE" >&2 || true
+      exit 1
+    fi
+    echo "==> 鉴权：带 cookie 应 200"
+    CODE="$(curl -sS -b "$SMOKE_COOKIE" -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
+    if [ "$CODE" != "200" ]; then
+      echo "错误：带 cookie 应返 200，实际 $CODE" >&2
+      echo "--- 诊断：直连容器内 dsh 3080（带 cookie）---" >&2
+      docker exec "$CID" curl -sS -b "$SMOKE_COOKIE" -o /dev/null -w '  HTTP %{http_code}\n' "http://127.0.0.1:3080/" >&2 || true
+      docker logs "$CID" 2>&1 | tail -20 | sed 's/^/    /' >&2
+      exit 1
+    fi
+    echo "    鉴权通过（cookie 持久化到 $SMOKE_HOME/.dsh/.credentials.yaml）"
+    # 新版路径：API fence 步骤用 cookie
+    AUTH_FLAGS=(-b "$SMOKE_COOKIE")
+    ;;
+esac
 
 echo "==> 特权 API fence：伪造 Host 直连容器内 dsh 应 403（fence 拒绝未授权来源）"
-# 不经 Caddy 直连 127.0.0.1:3080，伪造浏览器 Host=evil.com——dsh 视其为非本机来源
-CODE="$(docker exec "$CID" curl -s -o /dev/null -w '%{http_code}' -X POST \
+# 不经 Caddy 直连 127.0.0.1:3080，伪造浏览器 Host=evil.com——dsh 视其为非本机来源。
+# 此处用容器内 curl（不经 caddy，caddy 不参与；用 cookie/basic auth 都无法过 dsh 的
+# Host 来源检查——fence 拒绝非 loopback Host；仅 0.1.2-rc.1+ 需 cookie，0.1.1-rc.2 用 basic auth）
+#
+# Bypass Caddy: curl dsh 3080 directly from inside the container. dsh's fence rejects
+# non-loopback Host. Auth flavor: 0.1.1-rc.2 uses basic auth, 0.1.2-rc.1+ uses cookie.
+# Either way, the fake Host=evil.com is what we test, not auth.
+CODE="$(docker exec "$CID" curl -s "${AUTH_FLAGS[@]}" -o /dev/null -w '%{http_code}' -X POST \
   -H 'Host: evil.com' -H 'Content-Type: application/json' -d '{}' \
   "http://127.0.0.1:3080/api")"
 [ "$CODE" = "403" ] || { echo "错误：fence 未拒绝伪造 Host（期望 403 实际 $CODE）" >&2; exit 1; }
@@ -125,7 +200,7 @@ CODE="$(docker exec "$CID" curl -s -o /dev/null -w '%{http_code}' -X POST \
 echo "==> 特权 API fence：经 Caddy 伪造 Host/Origin 应被改写为 loopback（非 403）"
 # 浏览器形态请求经 Caddy：Host/Origin 被改写为 127.0.0.1:3080，fence 通过；
 # 若 Caddyfile 的 header_up 两行失效，此处将返回 403——即改写链路回归
-CODE="$(curl -s -u admin:smoketest -o /dev/null -w '%{http_code}' -X POST \
+CODE="$(curl -s "${AUTH_FLAGS[@]}" -o /dev/null -w '%{http_code}' -X POST \
   -H 'Host: evil.com' -H 'Origin: http://127.0.0.1:3080' \
   -H 'Content-Type: application/json' -d '{}' "http://127.0.0.1:$PORT/api")"
 [ "$CODE" = "400" ] || [ "$CODE" = "404" ] || { echo "错误：期望改写生效（400/404，fence 通过后坏 payload 的正常响应）实际 $CODE" >&2; exit 1; }

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -27,12 +27,27 @@ serverurl=unix:///var/run/supervisor.sock
 # dsh Web 客户端
 # 仅绑定容器内 loopback，不对外暴露
 # 注意：不传 --trusted-host（该 CLI 链路在 rc.6 不可靠），trustedHosts 走 cordis.patch.yml
+# --no-open：dsh 0.1.2-rc.1 默认尝试调系统命令打开浏览器，容器内无浏览器且无意义；
+# 也会污染 stdout（多一行 `opening the default browser; pass --no-open to disable`）。
+# 0.1.1-rc.2 也有该 flag，向后兼容
 #
 # dsh Web client
 # Binds only to the in-container loopback, never exposed externally
 # Note: --trusted-host is not passed (unreliable in rc.6); trustedHosts goes through cordis.patch.yml
+# --no-open: dsh 0.1.2-rc.1's web mode tries to invoke the system default browser on startup;
+# useless inside a headless container, and the error message clutters stdout
+# (`opening the default browser; pass --no-open to disable`). The flag also exists in 0.1.1-rc.2.
 [program:dsh]
-command=/usr/local/bin/dsh --profile web --port 3080
+# dsh 输出经 tee 同时落到 /dev/stdout（docker logs 可见）和 /home/node/.dsh/web-server.log
+# （让 entrypoint 后台进程可以从中提取 0.1.2-rc.1 启动时打印的 `?token=XXX`）。
+# 直接在 command 里 tee 比 supervisord 的 stdout_logfile 灵活——后者要么走 /dev/stdout 要么走
+# 文件，二选一；用 shell 包装可以同时保留两条管道
+#
+# dsh output is teed to /dev/stdout (docker logs) and to /home/node/.dsh/web-server.log
+# (so the entrypoint can grep the 0.1.2-rc.1 one-time `?token=XXX`). Tee in command
+# rather than stdout_logfile because the latter is exclusive: /dev/stdout OR a file, not both.
+# The shell wrapper costs a subshell but keeps both pipelines intact.
+command=/bin/sh -c "exec /usr/local/bin/dsh --profile web --port 3080 --no-open 2>&1 | tee -a /home/node/.dsh/web-server.log"
 # x-cmd 工具经 entrypoint 软链进 /usr/local/bin（agent bash 的 PATH 白名单固定，接入方式见 entrypoint x-cmd 段）
 #
 # x-cmd tools are symlinked into /usr/local/bin by the entrypoint (the agent bash PATH whitelist is fixed; see the entrypoint's x-cmd section)


### PR DESCRIPTION
## 背景 | Context

dsh 0.1.2-rc.1 引入了浏览器 Host API 鉴权机制（commit 3e24087bfa `fix(web): authenticate the browser Host API`，0.1.2-alpha.1 起生效）：

- dsh 启动时打印 `?token=<43 字符 base64url>` 一次性 URL
- 浏览器 GET 该 URL → 303 redirect + Set-Cookie（HttpOnly, SameSite=Strict）
- 后续 API 调用带 cookie；cookie 持久化在 `$DSH_HOME/.credentials.yaml`（mode 0o600），重启后仍有效
- **无 token 无 cookie** → 401 `unauthorized`

同时 dsh 0.1.2-rc.1 的 web 模式显式拒绑 `--host 0.0.0.0`（上游 packages/bundle/web-app/src/startup.ts）—— 反代是当前唯一让外部访问到 3080 的方式。

## 鉴权重复 | Duplicated auth

旧版（≤0.1.1-rc.2）的 Caddy basic auth（`DSH_AUTH_USER` / `DSH_AUTH_PASSWORD` 派生 bcrypt）现在与 dsh 自身的 token+cookie 鉴权**重复**。更糟的是 caddy basic auth 会拦截浏览器首次访问根路径的 redirect——用户根本看不到 dsh 的 token URL，无法完成首次认证。

## 修复 | Fix

### 第一轮（commit ffd0bdb）— 核心适配

七处改动：

1. **Caddyfile** — 去掉 `basic_auth`，保留 reverse_proxy + header_up（改写 Host/Origin 为 loopback 配合 dsh 的 anti-DNS-rebinding fence）
2. **entrypoint.sh** — DSH_AUTH_USER/PASSWORD 改为可选；未提供时写 bcrypt 格式占位让 Caddyfile 解析通过且任何 basic auth 试探必 401；后台任务抓 dsh 输出的 `?token=XXX` 写到 `$DHS_HOME/web-launch-url.txt`
3. **supervisord.conf** — dsh 启动加 `--no-open`；用 sh 包装 tee 让 dsh 输出同时到 `/dev/stdout`（docker logs）和 `$DHS_HOME/web-server.log`（entrypoint 抓 token 用）
4. **docker-compose.yml** — healthcheck 改用 token+cookie 流程：读 web-launch-url.txt → 303 拿 cookie → -b cookie 测 / 200
5. **scripts/smoke-test.sh** — 按 dsh 版本分叉：≤0.1.1 走 basic auth，≥0.1.2-rc.1 走 token+cookie；`$AUTH_FLAGS` 数组让 API fence 等步骤在两路径都正确鉴权
6. **.env.example** — DSH_AUTH_USER/PASSWORD 标 deprecated/optional，默认值保留以兼容回退
7. **README.md / README.zh.md** — 新增「读 docker logs 或 web-launch-url.txt 拿一次性 token URL → 浏览器访问该 URL」流程；密码章节拆为 dsh 0.1.2-rc.1+（重置数据卷）vs 旧版（改 env）

### 第二轮（commit 26167c8）— Oracle 审查反馈

Oracle 审查发现 7 条必修问题（详见 commit message），最严重的是 **PR 描述说升级到 0.1.2-rc.1+ 但 Dockerfile / docker-compose.yml 默认 DSH_VERSION 仍是 0.1.1-rc.2**——用户只 `docker compose pull` 会同时遇到「web 服务裸奔（新 Caddyfile 无 basic auth + 旧 dsh 无 token 鉴权）」+「healthcheck 永远 unhealthy（token 流程对旧 dsh 无效）」双重失败。

修复：

1. **Dockerfile:23** `ARG DSH_VERSION` 0.1.1-rc.2 → **0.1.2-rc.1**
2. **docker-compose.yml:16** `${DSH_VERSION:-...}` 默认值同步到 **0.1.2-rc.1**
3. **.env.example:39-40** 注释与默认同步到 **0.1.2-rc.1**（原 0.1.0-rc.6 与实际值不一致）
4. **README.md:37 / README.zh.md:37** 移除 `${DSH_VERSION:-latest}`（不是合法 npm dist-tag），改为具体版本 `0.1.2-rc.1`
5. **README.md / README.zh.md** Quick Start 加 `⚠️ 升级警告` blockquote，强制要求 `git pull` 同步仓库文件
6. **README.md / README.zh.md**「修改密码 / 重置鉴权」章节自相矛盾描述修正，明确「必须 `down -v`」+ 警告其破坏性 + 保留子路径指引
7. **docker-compose.yml** healthcheck 注释里的字面 `0.1.2-rc.1` 改用抽象表达（`0.1.2 系列` / `0.1.2+`）—— 避免破坏 `tests/test-scripts.sh` 的升级断言（脚本只处理 `${DSH_VERSION:-...}` 精确上下文，注释里的字面版本号不会自动替换）
8. **entrypoint.sh** DSH_AUTH_HASH 派生块注释从「无害保留」改写为「为回退兼容保留，当前 image 无消费者」，避免 reviewer 误判为死代码

**验证**：tests/test-scripts.sh 39/39 通过，bash -n + shellcheck + autocorrect 干净。

## 端口兼容 | Port compatibility

宿主机 `DSH_WEB_PORT`（默认 3080）→ 容器 3081 → dsh 3080，三层保持不变。外部访问方式从「basic auth 直进」变为「token URL 重定向拿 cookie」，但**端口不变**——现有用户挂的容器升级后无需改 docker-compose / 反代配置，只需按 README 新流程走首次访问。

## 升级路径 | Upgrade path

**正确流程**（README Quick Start 已加 `⚠️` 硬警告）：

```bash
cd deepseek-harness-web-docker
git pull                     # 同步 docker-compose.yml / Caddyfile / entrypoint.sh（必须）
docker compose pull          # 拉新 image
docker compose up -d         # 重启
docker compose logs dsh-web | grep 'dsh web:'   # 拿 token URL
# 浏览器访问该 token URL → 303 + Set-Cookie → 后续免 token
```

**错误流程**（PR 描述阶段漏改默认 DSH_VERSION 时会触发）：

```bash
git pull
# 旧 docker-compose.yml 的 DSH_VERSION:-0.1.1-rc.2 拉旧 image
# 旧 Caddyfile 还在 basic auth，新 dsh 0.1.2-rc.1 的 token URL 被 caddy 拦
# → 502 持续 / token URL 不可见 / 健康检查永远 unhealthy
```

**已避免**：第二轮 commit 把 `DSH_VERSION` 默认升到 0.1.2-rc.1，单一 `docker compose pull` 也能拿到正确 image。

## 回退路径 | Rollback

`DSH_AUTH_USER` / `DSH_AUTH_PASSWORD` 保留为兼容位，回退到 ≤0.1.1 系列时 healthcheck 需改回 basic auth（commit message 提示）。Dockerfile / entrypoint 仍派生 `DSH_AUTH_HASH` 以支持回退到旧 Caddyfile（从 git history 拉回旧 Caddyfile 块即可）。

## 测试 | Tests

- `bash -n` + `shellcheck` + `autocorrect` 全干净
- `tests/test-scripts.sh` **39/39** 通过
- smoke-test.sh 的 `case $VERSION` 分叉（≤0.1.1 走 basic auth / ≥0.1.2-rc.1 走 token+cookie）按 `VERSION` 字符串动态选路径，无新单测（smoke-test.sh 本身需 docker in docker 不能在 CI 跑，分叉逻辑简单不过度测试）

## 与 PR #5 / #6 的关系 | Relation to PRs #5 and #6

- PR #5（cleanup + HTTP 240s 阈值）已 merge 在 master
- PR #6（401 诊断 + 就绪判断）仍 open；本 PR 的 token 流程吸收了它的就绪判断改进（200/401/URL file 三选一），失败时的诊断块被 token 流程的诊断覆盖。建议合本 PR 后由 reviewer 关闭 PR #6

## 已知与后续 | Known and follow-up

- 上游 dsh 0.1.2-rc.1+ 还在 rc/alpha 迭代，未来 0.1.2 正式版或 0.1.3-alpha.x 可能有行为变更
- **Oracle 改进项**（合并后或下次再做，不阻塞本 PR）：
  - entrypoint grep 正则放宽（字符数 43 硬编码 → `{16,128}`）
  - token URL 不入 docker logs（远程集中日志系统会泄露）
  - entrypoint 抓 token 改为长期守护而非 `grep -m1`（让 `.credentials.yaml` 单文件删除后能轻量重置）
  - DESIGN.md §10 加版本演进记录
  - healthcheck `start_period` 120s → 180s