### PR TITLE
【修复，构建】修复自动升级冒烟测试并让 PR 触发验证

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,12 +1,17 @@
-# 自动构建并推送 GHCR：push master 或手动/workflow_dispatch 触发
+# 自动构建并推送 GHCR：push master、pull_request 或手动/workflow_dispatch 触发
 # 镜像 tag：latest + 日期时间 - 提交哈希（如 20260815T0054-a1b2c3d）
+# PR 只跑 verify（构建 + 冒烟），不推送镜像：fork PR 的 GITHUB_TOKEN 无 GHCR 写权限，
+# 且未合并的代码不应发布。verify 作为合并门禁，挡住不合规提交（需配合分支保护的必需检查）。
 # workflow_dispatch 提供两种钩入方式：
 #   - 手动：Actions 页面点「Run workflow」或 gh workflow run docker-build.yml
 #   - 被钩：upstream-check 自动升级推送后显式触发——bot 用 GITHUB_TOKEN 推送的提交不会触发
 #           push 事件（GitHub 递归保护），而 workflow_dispatch 是 GITHUB_TOKEN 的例外，总是创建 run
 #
-# Auto-build and push to GHCR: triggered on push to master or manual/API dispatch
+# Auto-build and push to GHCR: triggered on push to master, pull_request, or manual/API dispatch
 # Image tags: latest + datetime-commit-hash (e.g. 20260815T0054-a1b2c3d)
+# PRs run verify only (build + smoke) and never push images: a fork PR's GITHUB_TOKEN cannot
+# write GHCR, and unmerged code must not be published. verify acts as a merge gate against
+# non-compliant submissions (pair it with branch protection's required checks).
 # workflow_dispatch offers two hook-in paths:
 #   - Manual: click "Run workflow" in the Actions tab or gh workflow run docker-build.yml
 #   - Hooked: upstream-check dispatches explicitly after an auto-upgrade push—commits pushed by
@@ -17,18 +22,21 @@ name: build-push-ghcr
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 env:
   IMAGE: ghcr.io/xidong-ai/deepseek-harness-web-docker
 
 jobs:
-  # 推送前冒烟：构建镜像并跑端到端检查（basic auth / 特权 API fence / 双进程 / trustedHosts 注入），失败则不推送
-  # 手动 push 的代码不再未经验证直接发布
+  # 推送前冒烟：构建镜像并跑端到端检查（鉴权 token/cookie 或 basic auth / 特权 API fence / 双进程 / trustedHosts 注入），失败则不推送
+  # push 与 PR 共用同一套检查：push 失败阻断发布，PR 失败阻断合并（需分支保护勾选该检查为必需）
   #
-  # Pre-push smoke test: build the image and run end-to-end checks (basic auth / privileged-API fence /
-  # both processes / trustedHosts injection); a failure blocks the push, so manually pushed code
-  # is no longer published unverified
+  # Pre-push smoke test: build the image and run end-to-end checks (token/cookie or basic auth /
+  # privileged-API fence / both processes / trustedHosts injection); a failure blocks the push.
+  # push and PR share the same checks: a push failure blocks release, a PR failure blocks merge
+  # (requires the check to be marked required in branch protection)
   verify:
     runs-on: ubuntu-latest
     permissions:
@@ -47,6 +55,12 @@ jobs:
 
   build:
     needs: verify
+    # PR 只做验证，不发布镜像（fork PR 的 GITHUB_TOKEN 无 packages:write，且未合并代码不应发布）；
+    # 仅 push master / 手动 dispatch 推送 GHCR
+    #
+    # PRs verify only and never publish images (a fork PR's GITHUB_TOKEN has no packages:write,
+    # and unmerged code must not be released); GHCR is pushed only on push to master / manual dispatch
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,7 +72,7 @@ DSH v0.1 无内置认证，且特权 API（`settings.*`/`credentials.*`，`PRIVI
 | 13 | 与现有部署关系 | 独立通用项目，推送给用户；本机测试用另一端口，不影响现有 pm2 部署 |
 | 14 | 分发 | 源码（Dockerfile + compose）+ CI 自动构建推 GHCR |
 | 15 | GHCR 路径 | `ghcr.io/xidong-ai/deepseek-harness-web-docker` |
-| 16 | CI 触发/tag | push master 触发；镜像 tag = 日期时间 + 提交哈希（另推 `latest` 便于 compose 默认引用） |
+| 16 | CI 触发/tag | push master、pull_request 触发；PR 仅跑 verify（不推镜像，作合并门禁）；镜像 tag = 日期时间 + 提交哈希（另推 `latest` 便于 compose 默认引用） |
 
 ## 4. 文件清单
 
@@ -143,7 +143,7 @@ deepseek-harness-web-docker/
     config:
       trustedHosts: []
   ```
-- **.github/workflows/docker-build.yml**：`on: push: branches: [master]`；buildx（`linux/amd64`，可选 `linux/arm64` 多架构）→ tag `latest` + `${日期时间}-${sha7}`（如 `20260815T0054-a1b2c3d`）→ push `ghcr.io/xidong-ai/deepseek-harness-web-docker`（用 `GITHUB_TOKEN`，组织级包权限需在仓库设置开启）
+- **.github/workflows/docker-build.yml**：`on: push: branches: [master]` + `pull_request: branches: [master]`；push/PR 均先跑 `verify`（构建 + 冒烟），PR 仅此一步、不推镜像；push 通过后 buildx（`linux/amd64`，可选 `linux/arm64` 多架构）→ tag `latest` + `${日期时间}-${sha7}`（如 `20260815T0054-a1b2c3d`）→ push `ghcr.io/xidong-ai/deepseek-harness-web-docker`（用 `GITHUB_TOKEN`，组织级包权限需在仓库设置开启）
 
 ## 5. 环境变量参考（.env.example）
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cp .env.example .env    # edit DEEPSEEK_API_KEY (DSH_AUTH_USER/PASSWORD are now 
 docker compose up -d    # pull the latest image and start
 ```
 
-> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时,必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` / `entrypoint.sh 内的 token 抓取后台任务`,仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔(无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
+> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时，必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` / `entrypoint.sh 内的 token 抓取后台任务`,仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔 (无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
 
 ### Option 2: Build locally
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Containerized deployment of the [DeepSeek Harness](https://github.com/deepseek-a
 - Built-in health check: `docker compose ps` shows the real service health (`starting`/`healthy`/`unhealthy`), exchanging the one-time token for a cookie and probing dsh
 - Pinnable image version: build argument `DSH_VERSION`
 - CI automatically builds and pushes `ghcr.io/xidong-ai/deepseek-harness-web-docker` (latest + date-time-hash tags)
+- Every pull request runs the same build + smoke test as a merge gate (PRs never push images); publishing happens only on push to master or manual dispatch
 - A scheduled CI job checks the dsh upstream daily: on a new version it bumps `DSH_VERSION`, builds and smoke-tests the image, pushes to master on success, or opens an Issue on failure (a failed version is not retried automatically while its Issue is open; manual dispatch bypasses the gate)
 - The GHCR release can be triggered manually (Actions tab → "Run workflow") or is hooked automatically after an upstream auto-upgrade (`workflow_dispatch`)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,7 +29,7 @@ cp .env.example .env    # 编辑 DEEPSEEK_API_KEY（DSH_AUTH_USER/PASSWORD 自 0
 docker compose up -d    # 拉取 latest 镜像并启动
 ```
 
-> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时,必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` 内的 token 抓取后台任务,仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔(无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
+> ⚠️ **升级警告 — 升级到含 dsh 0.1.2-rc.1+ 鉴权迁移的版本时，必须先 `git pull` 同步 `docker-compose.yml` / `Caddyfile` / `entrypoint.sh` 内的 token 抓取后台任务，仅 `docker compose pull` 拉新 image 配旧 compose 文件会导致 healthcheck 永远 unhealthy 且 web 服务裸奔 (无鉴权)。** 具体见 PR #7 的 commit message 与 DESIGN.md §10 的版本演进记录。
 
 ### 方式二：本地构建
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,6 +15,7 @@
 - 内置健康检查：`docker compose ps` 直接可见服务真实健康状态（抓 dsh 一次性 token 换 cookie 后探测 dsh 响应，`starting`/`healthy`/`unhealthy`）
 - 镜像版本可 pin：构建参数 `DSH_VERSION`
 - CI 自动构建并推送 `ghcr.io/xidong-ai/deepseek-harness-web-docker`（latest + 日期时间 - 哈希 tag）
+- 每个合并请求都会运行与发布前相同的构建 + 冒烟测试作为合并门禁（PR 不推送镜像）；仅 push master 或手动触发才发布
 - 定时任务每日检查 dsh 上游：有新版本自动提升 `DSH_VERSION`、构建并冒烟测试，通过则推送 master 并钩住触发 GHCR 发布，失败则创建 Issue（存在同版本未关闭 Issue 时不再自动重试，可手动触发强制重试）
 - GHCR 发布可手动触发（Actions 页「Run workflow」）或由上游升级自动钩住触发（`workflow_dispatch`）
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -199,7 +199,19 @@ fi
 # 0.1.1-rc.2 doesn't print this URL, so on older dsh the file stays empty — harmless.
 WEB_LOG="$DHS_HOME/web-server.log"
 WEB_URL_FILE="$DHS_HOME/web-launch-url.txt"
-touch "$WEB_LOG"  # 让 tail -F 立即可订阅（dsh 启动后追加）
+# 预创建必须让 node 可写：entrypoint 以 root 运行，裸 touch 会留下 root:root 0644，
+# supervisord 中 dsh 以 user=node 执行 `tee -a` 追加时 EACCES，启动日志（含 ?token= URL）
+# 永远写不进文件，后台 tail 也就抓不到 token。故创建后立即把属主交给 node。
+# 仅首启会触发：文件已存在且属主正确时 touch 不改属主，二次启动天然正常。
+#
+# Pre-creation must leave the file writable by node: the entrypoint runs as root, so a bare
+# touch leaves root:root 0644 and dsh's `tee -a` under user=node fails with EACCES — the
+# startup log (including the ?token= URL) never reaches the file, so the background tail
+# cannot extract the token. Hand ownership to node right after creation.
+# First run only: when the file already exists with the right owner, touch keeps it,
+# so subsequent starts are fine.
+touch "$WEB_LOG"
+chown node:node "$WEB_LOG"
 (
   # 在子 shell 中等 + 抓 + 写 + 退出；不影响 entrypoint 主体
   #

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -70,6 +70,17 @@ echo "==> 启动容器冒烟"
 SMOKE_PARENT="${RUNNER_TEMP:-${TMPDIR:-$HOME}}"
 mkdir -p "$SMOKE_PARENT"
 SMOKE_HOME="$(mktemp -d -p "$SMOKE_PARENT" smoke-XXXXXX)"
+# mktemp 默认 0700。容器首启会把 bind mount 根 chown 成 node(uid 1000)，但权限位不变：
+# runner（GitHub Actions 上是 uid 1001）便无法 traverse，即使 web-launch-url.txt 已生成
+# 也读不到（表现为 60s 超时 + `tail: Permission denied`）。放宽目录到 755 让 runner 能进入，
+# 文件本身仍是 0644（只读）。本地跑时 runner uid 恰好也是 1000，不触发，故 CI 才暴露。
+#
+# mktemp defaults to 0700. The container's first-run chowns the bind-mount root to
+# node (uid 1000) without changing mode bits, so the runner (uid 1001 on GitHub Actions)
+# cannot traverse it and cannot read web-launch-url.txt even once it exists (symptom:
+# 60 s timeout + `tail: Permission denied`). Loosen the directory to 755 so the runner
+# can enter; files stay 0644 (read-only). Local runs use uid 1000, so only CI exposes this.
+chmod 755 "$SMOKE_HOME"
 mkdir -p "$SMOKE_HOME/.x-cmd.root/bin"
 printf '#!/bin/sh\nexit 0\n' > "$SMOKE_HOME/.x-cmd.root/bin/x"
 docker run -d --name "$CID" \

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -165,6 +165,15 @@ case "$VERSION" in
     fi
     LAUNCH_URL="$(cat "$URL_FILE")"
     echo "    抓取到 dsh 启动 URL: $LAUNCH_URL"
+    # URL_FILE 记录的是容器内 loopback 地址（dsh 强制 loopback bind），宿主机不能直连：
+    # 必须把主机：端口改写到映射端口 $PORT，才能经 Caddy 走真实浏览器路径；token 原样保留。
+    #
+    # URL_FILE holds the container-internal loopback address (dsh hard-binds loopback);
+    # the host cannot reach it directly. Rewrite host:port to the mapped port $PORT so the
+    # request goes through Caddy like a real browser; keep the token value as-is.
+    TOKEN="$(printf '%s' "$LAUNCH_URL" | sed -n 's#.*[?&]token=\([^&]*\).*#\1#p')"
+    [ -n "$TOKEN" ] || { echo "错误：无法从 $LAUNCH_URL 解析 token" >&2; exit 1; }
+    LAUNCH_URL="http://127.0.0.1:${PORT}/?token=${TOKEN}"
     # 一次性 token 换持久 cookie：GET ?token=XXX → 303 + Set-Cookie
     # Exchange one-time token for persistent cookie: GET ?token=XXX → 303 + Set-Cookie
     SMOKE_COOKIE="$(mktemp -p "$SMOKE_PARENT" smoke-cookie-XXXXXX)"
@@ -180,18 +189,29 @@ case "$VERSION" in
       cat "$SMOKE_COOKIE" >&2 || true
       exit 1
     fi
+    # cookie 同时要供宿主机 curl 与容器内 docker exec curl 使用，而 cookie 文件是宿主
+    # 路径、容器内不存在；统一抽成 Cookie header 字符串，两边都可用（HttpOnly cookie
+    # 在 curl 的 cookie jar 里以 #HttpOnly_ 前缀记录，解析时需一并纳入）。
+    #
+    # The cookie must work for both the host curl and the in-container `docker exec curl`,
+    # but the cookie jar is a host path that doesn't exist inside the container. Extract a
+    # Cookie header string usable on both sides (HttpOnly cookies are stored with a
+    # #HttpOnly_ prefix in curl's jar, so include them when parsing).
+    COOKIE_HEADER="Cookie: $(awk 'NF && ($1 ~ /^#HttpOnly_/ || $0 !~ /^#/) {print $6"="$7}' "$SMOKE_COOKIE" | paste -sd'; ' -)"
     echo "==> 鉴权：带 cookie 应 200"
-    CODE="$(curl -sS -b "$SMOKE_COOKIE" -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
+    CODE="$(curl -sS -H "$COOKIE_HEADER" -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/")"
     if [ "$CODE" != "200" ]; then
       echo "错误：带 cookie 应返 200，实际 $CODE" >&2
       echo "--- 诊断：直连容器内 dsh 3080（带 cookie）---" >&2
-      docker exec "$CID" curl -sS -b "$SMOKE_COOKIE" -o /dev/null -w '  HTTP %{http_code}\n' "http://127.0.0.1:3080/" >&2 || true
+      docker exec "$CID" curl -sS -H "$COOKIE_HEADER" -o /dev/null -w '  HTTP %{http_code}\n' "http://127.0.0.1:3080/" >&2 || true
       docker logs "$CID" 2>&1 | tail -20 | sed 's/^/    /' >&2
       exit 1
     fi
     echo "    鉴权通过（cookie 持久化到 $SMOKE_HOME/.dsh/.credentials.yaml）"
-    # 新版路径：API fence 步骤用 cookie
-    AUTH_FLAGS=(-b "$SMOKE_COOKIE")
+    # 新版路径：API fence 步骤用 cookie（header 字符串，host/容器通用）
+    #
+    # New auth path: the fence step uses the cookie (a header string, valid on host and in-container)
+    AUTH_FLAGS=(-H "$COOKIE_HEADER")
     ;;
 esac
 


### PR DESCRIPTION
## 问题

Issue #4：自动升级到 dsh 0.1.2-rc.1 时冒烟测试失败；PR #7 合并后的 `build-push-ghcr`（[run 34145440009](https://github.com/Xidong-AI/deepseek-harness-web-docker/actions/runs/34145440009)）也在同一处失败。

根因分两层（CI 日志可见）：

1. `entrypoint.sh` 以 root 预创建 `/home/node/.dsh/web-server.log` 后未改属主 → supervisord 中 dsh 以 `user=node` 执行 `tee -a` 追加时 `EACCES`，启动日志（含 `?token=…` URL）写不进文件 → entrypoint 后台 `tail` 抓不到 token → `web-launch-url.txt` 从未生成。
2. `scripts/smoke-test.sh` 的 `SMOKE_HOME` 由 `mktemp -d` 默认 `0700`；容器首启 `chown -R node:node /home/node` 把 bind mount 根改成 node(1000) 但权限位不变，runner(uid 1001) 无法 traverse，即使 token 文件已生成也读不到。

修好 token 提取后，又暴露出 PR #7 遗留的两处冒烟脚本缺陷（此前因 token 从未生成而未走到）：

3. `web-launch-url.txt` 记录的是容器内 `127.0.0.1:3080`（dsh 强制 loopback bind），宿主机 curl 直连失败（`curl: (7) ... 000`）。已改为解析 token 后改写到映射端口 `$PORT`，经 Caddy 走真实浏览器路径。
4. cookie jar 是宿主路径，`docker exec ... curl -b` 在容器内读不到；已抽出 Cookie header 字符串（含 `#HttpOnly_` 行），host 与容器内通用。

第 1、2 点只在**首启/全新数据卷**触发，故本地持久数据卷不易复现，CI 每次新建 `SMOKE_HOME` 必现。

## 改动

- `entrypoint.sh`：`touch "$WEB_LOG"` 后 `chown node:node`。
- `scripts/smoke-test.sh`：`mktemp -d` 后 `chmod 755 "$SMOKE_HOME"`；token URL 改写到映射端口；cookie 改为 header 字符串。
- `.github/workflows/docker-build.yml`：新增 `pull_request: branches:[master]` 触发；`build` job 加 `if: github.event_name != 'pull_request'`，PR 只跑 `verify`、不推镜像，作为合并门禁。
- README 双语 + DESIGN.md 同步；顺带修 README 既有标点/间距（autocorrect）。

## 验证

- Xidong-AI CI（本 PR 自动触发）：`verify` **通过**（[run 34260151311](https://github.com/Xidong-AI/deepseek-harness-web-docker/actions/runs/34260151311)，1m57s），含 token 交换、cookie 鉴权、特权 API fence、双进程、trustedHosts 注入全部通过；`build` 按预期跳过
- `bash -n` + `shellcheck` 通过
- `tests/test-scripts.sh` 39/39 通过
- 目录权限：uid 1001 容器读 700 目录被拒、755 目录可读
- 日志属主：root `touch` 后 uid 1000 追加被拒；`chown node:node` 后可写

## 合并后需维护者操作

- 在仓库分支保护中把 `verify` 勾为必需检查，PR 门禁才会真正阻挡合并（否则只是提示）
- 关闭 Issue #4（xidongbot 无 triage 权限）
- 合并后 push master 会触发 `build-push-ghcr` 发布 0.1.2-rc.1 镜像，自动更新闭环恢复

关联 #4
