### PR TITLE
【修复，CI】自动升级改为推送 PR 分支

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,8 +4,8 @@
 # 且未合并的代码不应发布。verify 作为合并门禁，挡住不合规提交（需配合分支保护的必需检查）。
 # workflow_dispatch 提供两种钩入方式：
 #   - 手动：Actions 页面点「Run workflow」或 gh workflow run docker-build.yml
-#   - 被钩：upstream-check 自动升级推送后显式触发——bot 用 GITHUB_TOKEN 推送的提交不会触发
-#           push 事件（GitHub 递归保护），而 workflow_dispatch 是 GITHUB_TOKEN 的例外，总是创建 run
+#   - 被钩：upstream-check 现将升级推送到 PR 分支 auto-upgrade/dsh；PR 由成员批准合并后，
+#           合并产生的 push 事件直接触发本工作流（成员合并的 push 会正常触发 CI）
 #
 # Auto-build and push to GHCR: triggered on push to master, pull_request, or manual/API dispatch
 # Image tags: latest + datetime-commit-hash (e.g. 20260815T0054-a1b2c3d)
@@ -14,9 +14,9 @@
 # non-compliant submissions (pair it with branch protection's required checks).
 # workflow_dispatch offers two hook-in paths:
 #   - Manual: click "Run workflow" in the Actions tab or gh workflow run docker-build.yml
-#   - Hooked: upstream-check dispatches explicitly after an auto-upgrade push—commits pushed by
-#             the bot's GITHUB_TOKEN do not fire the push event (GitHub recursion protection),
-#             while workflow_dispatch is the GITHUB_TOKEN exception and always creates a run
+#   - Hooked: upstream-check now pushes upgrades to the PR branch auto-upgrade/dsh; once a member
+#             approves and merges the PR, the merge push fires this workflow directly (a member's
+#             merge push triggers CI normally)
 name: build-push-ghcr
 
 on:

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -1,13 +1,17 @@
-# 定时检查 dsh 上游版本：有新版本 → 提升版本号 → 构建冒烟测试 → 通过则推送 master，失败则创建 Issue
-# 推送后显式触发 docker-build.yml 发布 GHCR 镜像，形成「升级 → 发布」闭环
-# 注意：bot 用 GITHUB_TOKEN 推送的提交不会触发 docker-build.yml 的 push 事件（GitHub 递归保护），
-#       因此发布必须通过 workflow_dispatch API 显式钩住（该事件是 GITHUB_TOKEN 的例外，总是创建 run）
+# 定时检查 dsh 上游版本：有新版本 → 提升版本号 → 构建冒烟测试 → 通过则推送常驻 PR 分支
+# auto-upgrade/dsh 并创建/更新唯一 PR（成员批准合并），失败则创建 Issue
+# 成员合并 PR 产生的 push 事件会自动触发 docker-build.yml 发布 GHCR 镜像，形成「升级 → 批准 → 发布」闭环
+# 注意：bot 用 GITHUB_TOKEN 创建的 PR 不会触发 docker-build.yml 的 pull_request 事件（GitHub 递归保护），
+#       属预期行为——冒烟测试已在升级流程内完成；成员合并的 push 会正常触发 CI
 #
-# Scheduled dsh upstream check: bump version on update → build & smoke test → push master on success, open an Issue on failure
-# After pushing, explicitly dispatch docker-build.yml to publish GHCR images — an "upgrade → release" loop
-# Note: commits pushed by the bot's GITHUB_TOKEN do NOT fire docker-build.yml's push event (GitHub
-#       recursion protection), so the release must be hooked explicitly via the workflow_dispatch
-#       API (the GITHUB_TOKEN exception that always creates a run)
+# Scheduled dsh upstream check: bump version on update → build & smoke test → push the standing PR
+# branch auto-upgrade/dsh and create/update the single PR (merged by a member approver), open an
+# Issue on failure
+# A member's merge push fires docker-build.yml automatically to publish GHCR images — an
+# "upgrade → approval → release" loop
+# Note: a PR created by the bot's GITHUB_TOKEN does NOT fire docker-build.yml's pull_request event
+#       (GitHub recursion protection); this is expected — the smoke test already ran inside the
+#       upgrade flow. A member's merge push triggers CI normally
 name: check-dsh-upstream
 
 on:
@@ -31,11 +35,13 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     outputs:
       current: ${{ steps.check.outputs.current }}
       latest: ${{ steps.check.outputs.latest }}
       should_upgrade: ${{ steps.check.outputs.should_upgrade }}
       blocked: ${{ steps.gate.outputs.blocked }}
+      blocked_pr: ${{ steps.gate-pr.outputs.blocked_pr }}
     steps:
       - uses: actions/checkout@v4
 
@@ -68,23 +74,58 @@ jobs:
         env:
           LATEST: ${{ steps.check.outputs.latest }}
 
+      # 门闩：auto-upgrade/dsh 分支上已有同版本 open PR 时跳过（避免每日重复推送同版本提交）
+      # 仅定时触发生效；手动触发（workflow_dispatch）绕过，用于人工强制刷新 PR
+      #
+      # Gate: skip when an open PR for this version already exists on auto-upgrade/dsh
+      # (avoid re-pushing the same version every day); manual dispatch bypasses it to force-refresh the PR
+      - name: 门闩检查：自动升级 PR
+        id: gate-pr
+        if: steps.check.outputs.should_upgrade == 'true' && github.event_name == 'schedule'
+        run: |
+          BLOCKED="$(scripts/check-pr-gate.sh "$LATEST")"
+          if [ "$BLOCKED" = "1" ]; then
+            BOOL=true
+            echo "auto-upgrade/dsh 已有 $LATEST 的 open PR，跳过本次自动升级（可手动触发强制刷新）"
+          else
+            BOOL=false
+          fi
+          # 布尔字符串输出：upgrade job 的 if 按 'true'/'false' 比较（与 issue 门闩同约定）
+          #
+          # Boolean string output: the upgrade job's if compares against 'true'/'false'
+          # (same convention as the Issue gate)
+          echo "blocked_pr=$BOOL" >> "$GITHUB_OUTPUT"
+        env:
+          LATEST: ${{ steps.check.outputs.latest }}
+
       - name: 打印检查结果
         run: |
           echo "当前版本 (current): ${{ steps.check.outputs.current }}"
           echo "上游最新 (latest):  ${{ steps.check.outputs.latest }}"
           echo "需要升级 (upgrade): ${{ steps.check.outputs.should_upgrade }}"
-          echo "被门闩拦截 (blocked): ${{ steps.gate.outputs.blocked }}"
+          echo "被 Issue 门闩拦截 (blocked): ${{ steps.gate.outputs.blocked }}"
+          echo "被 PR 门闩拦截 (blocked_pr): ${{ steps.gate-pr.outputs.blocked_pr }}"
 
   upgrade:
     needs: check
-    if: needs.check.outputs.should_upgrade == 'true' && needs.check.outputs.blocked != 'true'
+    if: needs.check.outputs.should_upgrade == 'true' && needs.check.outputs.blocked != 'true' && needs.check.outputs.blocked_pr != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
-      actions: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+
+      # 在版本提升前准备 PR 分支：分支不存在则从 master 新建；存在则合并 master 最新内容，
+      # 保证后续 push 为 fast-forward（ruleset 禁 force push；若先 bump 再切分支，bump 结果会被覆盖）
+      #
+      # Prep the PR branch BEFORE the version bump: create it from master, or merge master's latest,
+      # so the later push is fast-forward (the ruleset forbids force pushes; switching branches after
+      # the bump would clobber it)
+      - name: 准备 PR 分支
+        run: |
+          scripts/push-upgrade-pr.sh prepare
 
       - name: 提升版本号（Dockerfile / compose / README 双语）
         run: |
@@ -99,34 +140,28 @@ jobs:
         env:
           LATEST: ${{ needs.check.outputs.latest }}
 
-      - name: 推送升级至 master
+      # 提交升级、推送常驻 PR 分支并创建/更新唯一 PR（成员批准合并后，
+      # 合并 push 自动触发 docker-build.yml 发布 GHCR，无需显式 dispatch）
+      #
+      # Commit the upgrade, push the standing PR branch, and create/update the single PR
+      # (after a member approves and merges, the merge push fires docker-build.yml automatically;
+      # no explicit dispatch is needed)
+      - name: 推送升级分支并创建/更新 PR
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Dockerfile docker-compose.yml README.md README.zh.md
-          git commit -m "【维护，构建】升级 dsh 版本至 $LATEST"
-          git push origin master
+          scripts/push-upgrade-pr.sh push "$LATEST" "$CURRENT"
         env:
           LATEST: ${{ needs.check.outputs.latest }}
-
-      # 钩住 GHCR 发布（见文件头注释）。continue-on-error：升级推送已成功，触发失败不应把 job
-      # 标记失败——否则 failure() 会误建「构建冒烟测试失败」Issue；触发失败可在日志中排查或手动触发
-      #
-      # Hook the GHCR release (see the file header). continue-on-error: the upgrade push already
-      # succeeded, so a dispatch failure must not fail the job—otherwise failure() would falsely
-      # open a "smoke test failed" Issue; a failed dispatch can be investigated in the log or
-      # triggered manually
-      - name: 触发 GHCR 发布（docker-build.yml）
-        continue-on-error: true
-        run: |
-          gh workflow run docker-build.yml --ref master
-        env:
+          CURRENT: ${{ needs.check.outputs.current }}
+          # GH_TOKEN 显式透传：gh pr 需要凭据（脚本内亦有 GITHUB_TOKEN 兜底，这是双层防御）
+          #
+          # Pass GH_TOKEN explicitly: gh pr needs credentials (the script also falls back to
+          # GITHUB_TOKEN, so this is belt-and-suspenders)
           GH_TOKEN: ${{ github.token }}
 
-      # 升级已成功：旧版本的失败 Issue 均已过时，关闭以免陈旧累积
+      # 升级已提交为 PR：旧版本的失败 Issue 均已过时，关闭以免陈旧累积
       # continue-on-error：清理失败不影响升级结果（不触发下方 failure() 步骤）
       #
-      # The upgrade succeeded: failure Issues for older versions are stale; close them to avoid accumulation
+      # The upgrade is now a PR: failure Issues for older versions are stale; close them to avoid accumulation
       # continue-on-error: cleanup failure must not fail the upgrade (must not trigger the failure() step below)
       - name: 关闭过时的失败 Issue
         continue-on-error: true
@@ -142,10 +177,8 @@ jobs:
         env:
           LATEST: ${{ needs.check.outputs.latest }}
           CURRENT: ${{ needs.check.outputs.current }}
-          # GH_TOKEN 显式透传：与「触发 GHCR 发布」对齐，避免 gh 因无凭据报错
-          # (open-issue.sh 内部亦有 GITHUB_TOKEN 兜底，这是双层防御)
+          # GH_TOKEN 显式透传：避免 gh 因无凭据报错（open-issue.sh 内部亦有 GITHUB_TOKEN 兜底，这是双层防御）
           #
-          # Pass GH_TOKEN explicitly: matches the "Hook GHCR release" step; prevents gh from
-          # failing for lack of credentials. open-issue.sh also falls back to GITHUB_TOKEN,
-          # so this is belt-and-suspenders
+          # Pass GH_TOKEN explicitly: prevents gh from failing for lack of credentials.
+          # open-issue.sh also falls back to GITHUB_TOKEN, so this is belt-and-suspenders
           GH_TOKEN: ${{ github.token }}

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# 门闩检查：是否存在针对指定版本的未关闭「自动升级」PR（head 分支为 auto-upgrade/dsh）
+# 输出：1（存在，应跳过自动升级）/ 0（无，可继续）
+#
+# Gate check: whether an open auto-upgrade PR (head branch auto-upgrade/dsh) exists for the given version
+# Output: 1 (exists, skip the auto-upgrade) / 0 (none, proceed)
+# Usage: check-pr-gate.sh <version>
+#
+# 测试注入：设置 GH=/path/to/mock 可替换 gh 命令（用于单测）
+#
+# Test injection: set GH=/path/to/mock to substitute the gh command (used by unit tests)
+set -euo pipefail
+
+VERSION="$1"
+GH_BIN="${GH:-gh}"
+
+# 列出 auto-upgrade/dsh 分支上的 open PR，标题含目标版本即命中
+# simp: gh 仅输出 JSON，匹配交给 jq（mock 易仿真）；查询上限 10 条，常驻单 PR 远不会触及
+#
+# List open PRs on auto-upgrade/dsh; a title containing the target version is a hit
+# simp: gh only outputs JSON, matching is delegated to jq (easy to mock); the cap of 10 is far
+# above the standing single PR
+JSON="$("$GH_BIN" pr list --head auto-upgrade/dsh --state open --json title,number --limit 10 2>/dev/null || true)"
+[ -n "$JSON" ] || { echo 0; exit 0; }
+
+# 版本边界匹配（与 upgrade-dsh.sh 同思想）：先转义 VERSION 为正则字面量，再要求前后均非版本字符，
+# 避免把 0.2.0 误匹配为标题中 0.2.0-rc.1 的前缀（npm 版本字符集 [0-9A-Za-z.-]）
+#
+# Version-boundary match (same idea as upgrade-dsh.sh): escape VERSION to a regex literal, then
+# require non-version characters on both sides, so 0.2.0 is never matched as a prefix of
+# 0.2.0-rc.1 in a title (npm version chars [0-9A-Za-z.-])
+ESC="$(printf '%s' "$VERSION" | sed 's/[][\\^$.|*+?()]/\\&/g')"
+MATCH="$(jq -r --arg v "$ESC" '.[] | select(.title | test("(^|[^-0-9A-Za-z.])" + $v + "([^-0-9A-Za-z.]|$)")) | .number' <<<"$JSON" | head -n1)"
+[ -n "$MATCH" ] && echo 1 || echo 0

--- a/scripts/open-issue.sh
+++ b/scripts/open-issue.sh
@@ -23,7 +23,7 @@ CURRENT="$2"
 GH_BIN="${GH:-gh}"
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 export GH_TOKEN
-TITLE="[自动升级] dsh 上游 $LATEST 构建冒烟测试失败"
+TITLE="[自动升级] dsh 上游 $LATEST 升级流程失败"
 
 EXISTING="$("$GH_BIN" issue list --state open --search "in:title \"$TITLE\"" --json number -q '.[0].number' 2>/dev/null || true)"
 if [ -n "$EXISTING" ]; then
@@ -39,8 +39,8 @@ fi
 - 检测时间 (detected at): \`$(date -u +%FT%TZ)\`
 - 运行日志 (run log): ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 
-升级脚本已将 \`DSH_VERSION\` 提升至 \`$LATEST\` 并执行构建与冒烟测试，但未通过，代码**未推送**至 master。
-The upgrade script bumped \`DSH_VERSION\` to \`$LATEST\` and ran build & smoke tests, but they failed; the change was **not** pushed to master.
+升级脚本已将 \`DSH_VERSION\` 提升至 \`$LATEST\` 并执行构建与冒烟测试，但升级流程（冒烟测试或 PR 推送）未通过，代码**未进入** master。
+The upgrade script bumped \`DSH_VERSION\` to \`$LATEST\` and ran build & smoke tests, but the upgrade flow (smoke test or PR push) failed; the change did **not** reach master.
 
 请人工排查：上游版本是否可安装、容器是否可正常启动，修复后手动升级或等待下次定时检查。
 Please investigate: whether the upstream version installs and the container starts; fix it, then upgrade manually or wait for the next scheduled check.

--- a/scripts/push-upgrade-pr.sh
+++ b/scripts/push-upgrade-pr.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# 常驻 PR 分支的推送与 PR 维护脚本（两个子命令）
+#   prepare                     准备 PR 分支：从 master 新建，或合并 master 最新内容（保证后续 push 可 fast-forward）
+#   push <latest> <current>     提交升级、推送 auto-upgrade/dsh 分支并创建/更新唯一 PR
+# 版本提升（upgrade-dsh.sh）与冒烟测试（smoke-test.sh）由调用方在两个子命令之间完成
+#
+# Push and maintain the standing PR branch (two subcommands)
+#   prepare                      Prep the PR branch: create it from master, or merge master's latest
+#                                content (so the later push is guaranteed fast-forward)
+#   push <latest> <current>      Commit the upgrade, push auto-upgrade/dsh, and create/update the single PR
+# The version bump (upgrade-dsh.sh) and smoke test (smoke-test.sh) run between the two subcommands
+#
+# 测试注入：设置 GH=/path/to/mock 可替换 gh 命令（用于单测）
+#
+# Test injection: set GH=/path/to/mock to substitute the gh command (used by unit tests)
+set -euo pipefail
+
+BRANCH="auto-upgrade/dsh"
+
+# gh 凭据双兜底：GH_TOKEN 优先，回退 GITHUB_TOKEN（与 open-issue.sh 同模式）
+#
+# gh credential belt-and-suspenders: GH_TOKEN wins, GITHUB_TOKEN as fallback (same pattern as open-issue.sh)
+GH_BIN="${GH:-gh}"
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
+
+pr_body() { # <latest> <current>
+  local latest="$1" current="$2"
+  cat <<EOF
+## 自动升级 | Auto-upgrade
+
+- 上游版本 (upstream): \`$latest\`
+- 仓库当前版本 (repo current): \`$current\`
+- 变更文件 (files): Dockerfile / docker-compose.yml / README.md / README.zh.md
+- 运行日志 (run log): ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}
+
+升级脚本已提升版本并通过构建与冒烟测试（通过后才推送本分支）。
+The upgrade script bumped the version and passed build & smoke tests (this branch is pushed only after they pass).
+
+合并时请勾选 **Delete branch**，下次自动升级将重建分支。
+Please tick **Delete branch** when merging so the next auto-upgrade can recreate the branch.
+EOF
+}
+
+upsert_pr() { # <latest> <current>
+  local latest="$1" current="$2"
+  local title state
+  title="【维护，构建】升级 dsh 版本至 $latest"
+  # 该分支已有 OPEN PR 时编辑刷新；否则新建（无 PR / 已合并 / 已关闭）
+  #
+  # Edit an OPEN PR on this branch; otherwise create a new one (none / merged / closed)
+  state="$("$GH_BIN" pr view "$BRANCH" --json state -q '.state' 2>/dev/null || true)"
+  if [ "$state" = "OPEN" ]; then
+    "$GH_BIN" pr edit "$BRANCH" --title "$title" --body "$(pr_body "$latest" "$current")"
+  else
+    "$GH_BIN" pr create --base master --head "$BRANCH" --title "$title" --body "$(pr_body "$latest" "$current")"
+  fi
+}
+
+prepare_branch() {
+  # 分支不存在 → 从 master 新建；存在 → 合并 master 最新内容：
+  # 工作树回到 master 状态（-X theirs），并产生以远端分支 HEAD 为祖先的合并提交，
+  # 使后续 push 必然 fast-forward（ruleset 禁 force push 与删除分支）
+  #
+  # No branch → create from master; exists → merge master's latest:
+  # the worktree returns to master's state (-X theirs) and the merge commit descends from the
+  # remote branch HEAD, so the later push is guaranteed fast-forward
+  # (the ruleset forbids force pushes and branch deletion)
+  git fetch origin "$BRANCH" >/dev/null 2>&1 || true
+  if git rev-parse --verify -q "refs/remotes/origin/$BRANCH" >/dev/null; then
+    git checkout -B "$BRANCH" "origin/$BRANCH"
+    # -X theirs 仅能解决文本冲突；结构性冲突（如文件删除）会中止合并，由 set -e 转为失败 Issue 人工介入
+    #
+    # -X theirs only resolves textual conflicts; structural ones (e.g. file deletion) abort the
+    # merge and fail the job via set -e, surfacing as a failure Issue for human intervention
+    git merge --no-edit -X theirs master
+  else
+    git checkout -B "$BRANCH" master
+  fi
+}
+
+push_branch() { # <latest> <current>
+  local latest="$1" current="$2"
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git add Dockerfile docker-compose.yml README.md README.zh.md
+  git commit -m "【维护，构建】升级 dsh 版本至 $latest"
+  git push origin "$BRANCH"
+  upsert_pr "$latest" "$current"
+}
+
+main() {
+  case "${1:-}" in
+    prepare) prepare_branch ;;
+    push)
+      shift
+      push_branch "${1:?用法：push-upgrade-pr.sh push <latest> <current>}" \
+        "${2:?用法：push-upgrade-pr.sh push <latest> <current>}"
+      ;;
+    *) echo "用法：push-upgrade-pr.sh prepare|push <latest> <current>" >&2; exit 2 ;;
+  esac
+}
+
+# 仅在直接执行时进入 main；被 source（单测载入函数）时不执行
+#
+# Enter main only when executed directly; a source (unit tests loading functions) skips it
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# 单测：should-upgrade.sh（版本比较）与 upgrade-dsh.sh（文件更新）
+# 单测：should-upgrade.sh（版本比较）、upgrade-dsh.sh（文件更新）、open-issue.sh（失败 Issue）、
+# check-issue-gate.sh（失败 Issue 门闩）、close-stale-issues.sh（过时 Issue 清理）、
+# check-pr-gate.sh（自动升级 PR 门闩）与 push-upgrade-pr.sh 的 upsert_pr（PR 创建/更新）
+# git 分支准备与推送部分难 mock，由 CI 真机验证
 #
-# Unit tests: should-upgrade.sh (version comparison) and upgrade-dsh.sh (file updates)
+# Unit tests: should-upgrade.sh (version comparison), upgrade-dsh.sh (file updates), open-issue.sh
+# (failure Issue), check-issue-gate.sh (failure Issue gate), close-stale-issues.sh (stale Issue cleanup),
+# check-pr-gate.sh (auto-upgrade PR gate), and push-upgrade-pr.sh's upsert_pr (PR create/update)
+# The git branch prep and push parts are hard to mock and are verified live on CI
 # Usage: tests/test-scripts.sh
 set -euo pipefail
 
@@ -128,6 +134,10 @@ case "$1 $2" in
     ;;
   "issue create") echo "created" ;;
   "issue close") echo "closed $3" ;;
+  "pr list") echo "${MOCK_LIST_OUT-}" ;;
+  "pr view") echo "${MOCK_PR_STATE-}" ;;
+  "pr create") echo "created" ;;
+  "pr edit") echo "edited" ;;
 esac
 MOCK
 chmod +x "$MOCK_GH"
@@ -137,6 +147,7 @@ MOCK_LOG="$TMP/mock1.log" MOCK_LIST_OUT='[]' GH="$MOCK_GH" \
   "$OPEN_ISSUE" 0.2.0 0.1.0-rc.6 > "$TMP/issue1.out" 2>&1
 assert_grep "无已有 Issue 时创建"            "已创建 Issue" "$TMP/issue1.out"
 assert_grep "create 调用含新版本标题"         "issue create --title \[自动升级\] dsh 上游 0.2.0" "$TMP/mock1.log"
+assert_grep "create 标题为通用失败措辞"       "升级流程失败" "$TMP/mock1.log"
 assert_grep "create 调用含上游版本正文"        "0.2.0" "$TMP/mock1.log"
 
 MOCK_LOG="$TMP/mock2.log" MOCK_LIST_OUT='[{"number":7}]' GH="$MOCK_GH" \
@@ -206,6 +217,64 @@ MOCK_LOG="$TMP/mock8.log" MOCK_LIST_OUT='[]' GH="$MOCK_GH" \
   "$CLOSE" > "$TMP/close2.out" 2>&1
 assert_grep "无 Issue 时提示" "无过时的失败 Issue" "$TMP/close2.out"
 assert_no_grep "无 Issue 时不调用 close" "issue close" "$TMP/mock8.log"
+
+echo "== check-pr-gate.sh (mock gh)=="
+PRGATE="$ROOT/scripts/check-pr-gate.sh"
+PRGATE_LIST='[{"title":"【维护，构建】升级 dsh 版本至 0.2.0","number":11}]'
+
+MOCK_LOG="$TMP/prgate1.log" MOCK_LIST_OUT="$PRGATE_LIST" GH="$MOCK_GH" \
+  "$PRGATE" 0.2.0 > "$TMP/prgate1.out" 2>&1
+assert_eq "同版本 open PR 存在时拦截" 1 "$(cat "$TMP/prgate1.out")"
+
+MOCK_LOG="$TMP/prgate2.log" MOCK_LIST_OUT="$PRGATE_LIST" GH="$MOCK_GH" \
+  "$PRGATE" 0.2.1 > "$TMP/prgate2.out" 2>&1
+assert_eq "不同版本 PR 不拦截" 0 "$(cat "$TMP/prgate2.out")"
+
+# 版本前缀边界：0.2.0 不得匹配标题中的 0.2.0-rc.1（与 upgrade-dsh.sh 的边界替换同思想）
+#
+# Version-prefix boundary: 0.2.0 must not match 0.2.0-rc.1 in a title
+# (same idea as upgrade-dsh.sh's boundary replacement)
+PRGATE_RC='[{"title":"【维护，构建】升级 dsh 版本至 0.2.0-rc.1","number":12}]'
+MOCK_LOG="$TMP/prgate3.log" MOCK_LIST_OUT="$PRGATE_RC" GH="$MOCK_GH" \
+  "$PRGATE" 0.2.0 > "$TMP/prgate3.out" 2>&1
+assert_eq "版本前缀不误拦（0.2.0 vs 0.2.0-rc.1）" 0 "$(cat "$TMP/prgate3.out")"
+
+MOCK_LOG="$TMP/prgate4.log" MOCK_LIST_OUT='[]' GH="$MOCK_GH" \
+  "$PRGATE" 0.2.0 > "$TMP/prgate4.out" 2>&1
+assert_eq "无 PR 不拦截" 0 "$(cat "$TMP/prgate4.out")"
+
+MOCK_LOG="$TMP/prgate5.log" MOCK_LIST_OUT='' GH="$MOCK_GH" \
+  "$PRGATE" 0.2.0 > "$TMP/prgate5.out" 2>&1
+assert_eq "gh 查询失败（空输出）不拦截" 0 "$(cat "$TMP/prgate5.out")"
+
+echo "== push-upgrade-pr.sh upsert_pr (mock gh)=="
+# source 载入函数（脚本入口有 BASH_SOURCE 守卫，不执行 main）；
+# 需先设置 GH 再 source，使脚本顶部 GH_BIN 指向 mock
+#
+# Source to load the function (the script has a BASH_SOURCE guard and won't run main);
+# set GH before sourcing so the script's top-level GH_BIN points at the mock
+PRPUSH="$ROOT/scripts/push-upgrade-pr.sh"
+# shellcheck disable=SC1090
+GH="$MOCK_GH" source "$PRPUSH"
+
+MOCK_LOG="$TMP/prpush1.log" MOCK_PR_STATE=OPEN GH="$MOCK_GH" \
+  upsert_pr 0.2.0 0.1.0-rc.6 > "$TMP/prpush1.out" 2>&1
+assert_grep "PR 为 OPEN 时调用 edit" "pr edit auto-upgrade/dsh" "$TMP/prpush1.log"
+assert_grep "edit 标题含新版本" "升级 dsh 版本至 0.2.0" "$TMP/prpush1.log"
+
+MOCK_LOG="$TMP/prpush2.log" MOCK_PR_STATE='' GH="$MOCK_GH" \
+  upsert_pr 0.2.0 0.1.0-rc.6 > "$TMP/prpush2.out" 2>&1
+assert_grep "无 PR 时调用 create" "pr create" "$TMP/prpush2.log"
+assert_grep "create head 为常驻分支" "auto-upgrade/dsh" "$TMP/prpush2.log"
+assert_grep "create body 含上游版本" "0.2.0" "$TMP/prpush2.log"
+
+MOCK_LOG="$TMP/prpush3.log" MOCK_PR_STATE=MERGED GH="$MOCK_GH" \
+  upsert_pr 0.2.0 0.1.0-rc.6 > "$TMP/prpush3.out" 2>&1
+assert_grep "PR 已合并时重新 create" "pr create" "$TMP/prpush3.log"
+
+MOCK_LOG="$TMP/prpush4.log" MOCK_PR_STATE=CLOSED GH="$MOCK_GH" \
+  upsert_pr 0.2.0 0.1.0-rc.6 > "$TMP/prpush4.out" 2>&1
+assert_grep "PR 已关闭时重新 create" "pr create" "$TMP/prpush4.log"
 
 echo
 echo "结果：$PASS 通过，$FAIL 失败"


### PR DESCRIPTION
## 背景

9 月 10 日定时自动升级推送 master 被 GH013 拒绝（ruleset「成员审核」要求更改必须走 PR）。本 PR 将自动升级流程改为：bot 推送常驻 PR 分支并创建/更新唯一 PR，由成员批准合并。

## 新闭环

```
每日检查上游 → 提升版本 → 构建冒烟 → 通过则 push auto-upgrade/dsh 并创建/更新唯一 PR → 成员批准合并
                                          → 合并 push 自动触发 docker-build.yml 发布 GHCR
失败 → 创建去重 Issue（门闩：同版本失败 Issue 或同版本 open PR 存在时跳过）
```

## 改动

- `scripts/push-upgrade-pr.sh`（新增）：`prepare`（分支准备，保证 push 为 fast-forward——ruleset 禁 force push，先 bump 再切分支会覆盖工作树）/ `push`（提交、推送、创建或更新 PR）
- `scripts/check-pr-gate.sh`（新增）：PR 门闩，版本边界匹配（0.2.0 不会误拦 0.2.0-rc.1）
- `.github/workflows/upstream-check.yml`：check job 加 PR 门闩 + `pull-requests: read`；upgrade job 加 `pull-requests: write`，push master 改为 push PR 分支，删除显式 dispatch 步骤（成员合并的 push 会正常触发 CI）
- `scripts/open-issue.sh`：标题措辞通用化为「升级流程失败」（冒烟或 PR 推送失败皆适用）
- `.github/workflows/docker-build.yml`：更新过时注释
- `tests/test-scripts.sh`：新增 12 项用例，52/52 通过

## 验证

- `tests/test-scripts.sh` 52/52 通过；shellcheck、bash -n、YAML 校验、autocorrect 均通过
- 本地集成测试覆盖：首次建分支、squash 合并后分支未删的 fast-forward push、master 与 PR 分支文本冲突（-X theirs）

## 合并后

请手动触发一次 `check-dsh-upstream`（workflow_dispatch）验证完整闭环——它会将 0.1.5-rc.1 升级（master 仍停留在 0.1.2-rc.1）推送为 PR #?；合并自动升级 PR 时请勾选 **Delete branch**，便于下次重建分支。