### PR TITLE
【修复，CI】upgrade 拉取完整历史修复 merge 失败

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -115,7 +115,15 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # fetch-depth: 0（完整历史）：prepare 需合并远端 PR 分支，浅克隆（默认 depth=1）缺少共同祖先，
+      # merge 会报 "refusing to merge unrelated histories"
+      #
+      # fetch-depth: 0 (full history): prepare merges the remote PR branch and needs the common
+      # ancestor; a shallow clone (default depth=1) fails the merge with
+      # "refusing to merge unrelated histories"
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # 在版本提升前准备 PR 分支：分支不存在则从 master 新建；存在则合并 master 最新内容，
       # 保证后续 push 为 fast-forward（ruleset 禁 force push；若先 bump 再切分支，bump 结果会被覆盖）


### PR DESCRIPTION
## 背景

PR #12 合并后第三次手动验证，`prepare` 步骤报：

```
fatal: refusing to merge unrelated histories
```

## 根因

`actions/checkout@v4` 默认 `fetch-depth: 1`（浅克隆）。master 的 HEAD 是浅边界，其父提交不参与祖先计算；而 `auto-upgrade/dsh` 分支（第一次推送的 3d22c11）的历史起点在浅边界之外，merge-base 交集为空 → merge 报 unrelated histories。前两次 run 未触发是因为分支尚不存在 / 旧实现恰好不 merge。

## 修复

upgrade job 的 checkout 加 `fetch-depth: 0`（完整历史）。仓库历史很短，代价可忽略。

已在本地用 `--depth=1` 克隆复现，`--unshallow` 后 prepare 正常（工作树回到 master 内容）。