### PR TITLE
【修复，CI】门闩与清理脚本补齐 gh 凭据并修版本边界

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -73,6 +73,11 @@ jobs:
           echo "blocked=$BOOL" >> "$GITHUB_OUTPUT"
         env:
           LATEST: ${{ steps.check.outputs.latest }}
+          # GH_TOKEN 显式透传：gh 在 Actions 中需要凭据（脚本内亦有 GITHUB_TOKEN 兜底，双层防御）
+          #
+          # Pass GH_TOKEN explicitly: gh needs credentials in Actions
+          # (the script also falls back to GITHUB_TOKEN, belt-and-suspenders)
+          GH_TOKEN: ${{ github.token }}
 
       # 门闩：auto-upgrade/dsh 分支上已有同版本 open PR 时跳过（避免每日重复推送同版本提交）
       # 仅定时触发生效；手动触发（workflow_dispatch）绕过，用于人工强制刷新 PR
@@ -97,6 +102,11 @@ jobs:
           echo "blocked_pr=$BOOL" >> "$GITHUB_OUTPUT"
         env:
           LATEST: ${{ steps.check.outputs.latest }}
+          # GH_TOKEN 显式透传：gh 在 Actions 中需要凭据（脚本内亦有 GITHUB_TOKEN 兜底，双层防御）
+          #
+          # Pass GH_TOKEN explicitly: gh needs credentials in Actions
+          # (the script also falls back to GITHUB_TOKEN, belt-and-suspenders)
+          GH_TOKEN: ${{ github.token }}
 
       - name: 打印检查结果
         run: |
@@ -177,6 +187,11 @@ jobs:
           scripts/close-stale-issues.sh
         env:
           LATEST: ${{ needs.check.outputs.latest }}
+          # GH_TOKEN 显式透传：gh 在 Actions 中需要凭据（脚本内亦有 GITHUB_TOKEN 兜底，双层防御）
+          #
+          # Pass GH_TOKEN explicitly: gh needs credentials in Actions
+          # (the script also falls back to GITHUB_TOKEN, belt-and-suspenders)
+          GH_TOKEN: ${{ github.token }}
 
       - name: 失败时创建 Issue（同版本去重）
         if: failure()

--- a/scripts/check-issue-gate.sh
+++ b/scripts/check-issue-gate.sh
@@ -25,13 +25,22 @@ GH_BIN="${GH:-gh}"
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 export GH_TOKEN
 
-# 列出未关闭的自动升级失败 Issue，标题含目标版本即命中
-# simp: gh 仅输出 JSON，匹配交给 jq（mock 易仿真）；查询上限 50 条，按版本去重后远不会触及
+# 列出未关闭的自动升级失败 Issue，标题含目标版本即命中（匹配在下方按版本边界进行）
 #
 # List open auto-upgrade failure Issues; a title containing the target version is a hit
+# (matching below is done at version boundaries)
+# simp: gh 仅输出 JSON，匹配交给 jq（mock 易仿真）；查询上限 50 条，按版本去重后远不会触及
+#
 # simp: gh only outputs JSON, matching is delegated to jq (easy to mock); cap of 50 is far above the deduped per-version count
 JSON="$("$GH_BIN" issue list --state open --search 'in:title "[自动升级]"' --json title,number --limit 50 2>/dev/null || true)"
 [ -n "$JSON" ] || { echo 0; exit 0; }
 
-MATCH="$(jq -r '.[] | select(.title | contains("'"$VERSION"'")) | .number' <<<"$JSON" | head -n1)"
+# 版本边界匹配（与 check-pr-gate.sh / upgrade-dsh.sh 同思想）：先转义 VERSION 为正则字面量，
+# 再要求前后均非版本字符，避免 0.2.0 误匹配标题中的 0.2.0-rc.1（npm 版本字符集 [0-9A-Za-z.-]）
+#
+# Version-boundary match (same idea as check-pr-gate.sh / upgrade-dsh.sh): escape VERSION to a
+# regex literal, then require non-version characters on both sides, so 0.2.0 is never matched as
+# a prefix of 0.2.0-rc.1 in a title (npm version chars [0-9A-Za-z.-])
+ESC="$(printf '%s' "$VERSION" | sed 's/[][\\^$.|*+?()]/\\&/g')"
+MATCH="$(jq -r --arg v "$ESC" '.[] | select(.title | test("(^|[^-0-9A-Za-z.])" + $v + "([^-0-9A-Za-z.]|$)")) | .number' <<<"$JSON" | head -n1)"
 [ -n "$MATCH" ] && echo 1 || echo 0

--- a/scripts/check-issue-gate.sh
+++ b/scripts/check-issue-gate.sh
@@ -14,6 +14,17 @@ set -euo pipefail
 VERSION="$1"
 GH_BIN="${GH:-gh}"
 
+# GitHub Actions 兜底：CI 中 gh 必须有 GH_TOKEN，否则 exit 4；脚本内回退 GITHUB_TOKEN，
+# 调用方显式传入的 GH_TOKEN 仍优先（与 open-issue.sh / push-upgrade-pr.sh 同一双层防御）
+# 回归背景：本步骤曾漏配 env 且脚本无兜底，gh 报错被 2>/dev/null 吞掉 → 门闩静默恒不拦截
+#
+# GitHub Actions fallback: gh needs GH_TOKEN in CI or exits 4; fall back to GITHUB_TOKEN here.
+# An explicit GH_TOKEN still wins (same belt-and-suspenders as open-issue.sh / push-upgrade-pr.sh).
+# Regression: this step once lacked env and fallback, so gh's error was swallowed by 2>/dev/null
+# and the gate silently never blocked
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
+
 # 列出未关闭的自动升级失败 Issue，标题含目标版本即命中
 # simp: gh 仅输出 JSON，匹配交给 jq（mock 易仿真）；查询上限 50 条，按版本去重后远不会触及
 #

--- a/scripts/check-pr-gate.sh
+++ b/scripts/check-pr-gate.sh
@@ -14,6 +14,17 @@ set -euo pipefail
 VERSION="$1"
 GH_BIN="${GH:-gh}"
 
+# GitHub Actions 兜底：CI 中 gh 必须有 GH_TOKEN，否则 exit 4；脚本内回退 GITHUB_TOKEN，
+# 调用方显式传入的 GH_TOKEN 仍优先（与 open-issue.sh / push-upgrade-pr.sh 同一双层防御）
+# 回归背景：本步骤曾漏配 env 且脚本无兜底，gh 报错被 2>/dev/null 吞掉 → 门闩静默恒不拦截
+#
+# GitHub Actions fallback: gh needs GH_TOKEN in CI or exits 4; fall back to GITHUB_TOKEN here.
+# An explicit GH_TOKEN still wins (same belt-and-suspenders as open-issue.sh / push-upgrade-pr.sh).
+# Regression: this step once lacked env and fallback, so gh's error was swallowed by 2>/dev/null
+# and the gate silently never blocked
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
+
 # 列出 auto-upgrade/dsh 分支上的 open PR，标题含目标版本即命中
 # simp: gh 仅输出 JSON，匹配交给 jq（mock 易仿真）；查询上限 10 条，常驻单 PR 远不会触及
 #

--- a/scripts/close-stale-issues.sh
+++ b/scripts/close-stale-issues.sh
@@ -11,6 +11,17 @@ set -euo pipefail
 
 GH_BIN="${GH:-gh}"
 
+# GitHub Actions 兜底：CI 中 gh 必须有 GH_TOKEN，否则 exit 4；脚本内回退 GITHUB_TOKEN，
+# 调用方显式传入的 GH_TOKEN 仍优先（与 open-issue.sh / push-upgrade-pr.sh 同一双层防御）
+# 回归背景：本步骤曾漏配 env 且脚本无兜底，gh 报错被 2>/dev/null 吞掉 → 静默「无过时的失败 Issue」
+#
+# GitHub Actions fallback: gh needs GH_TOKEN in CI or exits 4; fall back to GITHUB_TOKEN here.
+# An explicit GH_TOKEN still wins (same belt-and-suspenders as open-issue.sh / push-upgrade-pr.sh).
+# Regression: this step once lacked env and fallback, so gh's error was swallowed by 2>/dev/null
+# and stale Issues were silently never closed
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
+
 JSON="$("$GH_BIN" issue list --state open --search 'in:title "[自动升级]"' --json title,number --limit 50 2>/dev/null || true)"
 [ -n "$JSON" ] || { echo "无过时的失败 Issue"; exit 0; }
 

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -202,6 +202,16 @@ MOCK_LOG="$TMP/mock6.log" MOCK_LIST_OUT='' GH="$MOCK_GH" \
   "$GATE" 0.2.0 > "$TMP/gate4.out" 2>&1
 assert_eq "gh 查询失败（空输出）不拦截" 0 "$(cat "$TMP/gate4.out")"
 
+# GitHub Actions 兜底：仅设 GITHUB_TOKEN 时应映射为 GH_TOKEN（回归：CI 步骤曾漏配 env 且脚本无兜底，
+# gh exit 4 被 2>/dev/null 吞掉 → 门闩静默恒不拦截）
+#
+# GitHub Actions fallback: GITHUB_TOKEN must be surfaced as GH_TOKEN (regression: the CI step
+# lacked env and the script had no fallback, so gh exit 4 was swallowed and the gate never blocked)
+GUARD_LOG="$TMP/mock_guard_gate.log" MOCK_LOG="$TMP/mock_guard_gate_gh.log" MOCK_LIST_OUT='[]' \
+  GH="$GH_TOKEN_GUARD" GH_REAL="$MOCK_GH" GITHUB_TOKEN=ghp_ci_fallback \
+  "$GATE" 0.2.0 > "$TMP/gate_guard.out" 2>&1
+assert_grep "gate：GITHUB_TOKEN 兜底为 GH_TOKEN" "GH_TOKEN=ghp_ci_fallback" "$TMP/mock_guard_gate.log"
+
 echo "== close-stale-issues.sh (mock gh)=="
 CLOSE="$ROOT/scripts/close-stale-issues.sh"
 CLOSE_LIST='[{"title":"[自动升级] dsh 上游 0.1.9 构建冒烟测试失败","number":9},{"title":"[自动升级] dsh 上游 0.2.0 构建冒烟测试失败","number":7}]'
@@ -217,6 +227,16 @@ MOCK_LOG="$TMP/mock8.log" MOCK_LIST_OUT='[]' GH="$MOCK_GH" \
   "$CLOSE" > "$TMP/close2.out" 2>&1
 assert_grep "无 Issue 时提示" "无过时的失败 Issue" "$TMP/close2.out"
 assert_no_grep "无 Issue 时不调用 close" "issue close" "$TMP/mock8.log"
+
+# GitHub Actions 兜底：仅设 GITHUB_TOKEN 时应映射为 GH_TOKEN（回归：CI 步骤曾漏配 env 且脚本无兜底，
+# gh exit 4 被 2>/dev/null 吞掉 → 静默「无过时的失败 Issue」，Issue 永不关闭）
+#
+# GitHub Actions fallback: GITHUB_TOKEN must be surfaced as GH_TOKEN (regression: the CI step
+# lacked env and the script had no fallback, so gh exit 4 was swallowed and stale Issues were never closed)
+GUARD_LOG="$TMP/mock_guard_close.log" MOCK_LOG="$TMP/mock_guard_close_gh.log" MOCK_LIST_OUT='[]' \
+  GH="$GH_TOKEN_GUARD" GH_REAL="$MOCK_GH" GITHUB_TOKEN=ghp_ci_fallback \
+  "$CLOSE" > "$TMP/close_guard.out" 2>&1
+assert_grep "close：GITHUB_TOKEN 兜底为 GH_TOKEN" "GH_TOKEN=ghp_ci_fallback" "$TMP/mock_guard_close.log"
 
 echo "== check-pr-gate.sh (mock gh)=="
 PRGATE="$ROOT/scripts/check-pr-gate.sh"
@@ -246,6 +266,16 @@ assert_eq "无 PR 不拦截" 0 "$(cat "$TMP/prgate4.out")"
 MOCK_LOG="$TMP/prgate5.log" MOCK_LIST_OUT='' GH="$MOCK_GH" \
   "$PRGATE" 0.2.0 > "$TMP/prgate5.out" 2>&1
 assert_eq "gh 查询失败（空输出）不拦截" 0 "$(cat "$TMP/prgate5.out")"
+
+# GitHub Actions 兜底：仅设 GITHUB_TOKEN 时应映射为 GH_TOKEN（回归：CI 步骤曾漏配 env 且脚本无兜底，
+# gh exit 4 被 2>/dev/null 吞掉 → PR 门闩静默恒不拦截）
+#
+# GitHub Actions fallback: GITHUB_TOKEN must be surfaced as GH_TOKEN (regression: the CI step
+# lacked env and the script had no fallback, so gh exit 4 was swallowed and the PR gate never blocked)
+GUARD_LOG="$TMP/mock_guard_prgate.log" MOCK_LOG="$TMP/mock_guard_prgate_gh.log" MOCK_LIST_OUT='[]' \
+  GH="$GH_TOKEN_GUARD" GH_REAL="$MOCK_GH" GITHUB_TOKEN=ghp_ci_fallback \
+  "$PRGATE" 0.2.0 > "$TMP/prgate_guard.out" 2>&1
+assert_grep "prgate：GITHUB_TOKEN 兜底为 GH_TOKEN" "GH_TOKEN=ghp_ci_fallback" "$TMP/mock_guard_prgate.log"
 
 echo "== push-upgrade-pr.sh upsert_pr (mock gh)=="
 # source 载入函数（脚本入口有 BASH_SOURCE 守卫，不执行 main）；

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -212,6 +212,14 @@ GUARD_LOG="$TMP/mock_guard_gate.log" MOCK_LOG="$TMP/mock_guard_gate_gh.log" MOCK
   "$GATE" 0.2.0 > "$TMP/gate_guard.out" 2>&1
 assert_grep "gate：GITHUB_TOKEN 兜底为 GH_TOKEN" "GH_TOKEN=ghp_ci_fallback" "$TMP/mock_guard_gate.log"
 
+# 版本边界：0.2.0 不得匹配 0.2.0-rc.1（与 check-pr-gate.sh 同思想）
+#
+# Version boundary: 0.2.0 must not match 0.2.0-rc.1 (same idea as check-pr-gate.sh)
+GATE_RC='[{"title":"[自动升级] dsh 上游 0.2.0-rc.1 升级流程失败","number":13}]'
+MOCK_LOG="$TMP/mock9.log" MOCK_LIST_OUT="$GATE_RC" GH="$MOCK_GH" \
+  "$GATE" 0.2.0 > "$TMP/gate5.out" 2>&1
+assert_eq "版本前缀不误拦（0.2.0 vs 0.2.0-rc.1）" 0 "$(cat "$TMP/gate5.out")"
+
 echo "== close-stale-issues.sh (mock gh)=="
 CLOSE="$ROOT/scripts/close-stale-issues.sh"
 CLOSE_LIST='[{"title":"[自动升级] dsh 上游 0.1.9 构建冒烟测试失败","number":9},{"title":"[自动升级] dsh 上游 0.2.0 构建冒烟测试失败","number":7}]'


### PR DESCRIPTION
## 背景

自动升级闭环首次成功（run 34487266068 → PR #15），但成功运行后发现 `close-stale-issues.sh` 打印「无过时的失败 Issue」，而 Issue #11 仍处于打开状态——三个 gh 脚本在 Actions 中实际静默失效。

## 根因

CI 中 gh 必须有 `GH_TOKEN`（否则 exit 4）。`check-issue-gate.sh` / `check-pr-gate.sh` / `close-stale-issues.sh` 均无 `GITHUB_TOKEN` 兜底，对应 workflow 步骤也未透传 `GH_TOKEN`，脚本里的 `2>/dev/null || true` 把报错吞成空结果：

- 失败 Issue 门闩 → 恒输出 0（从不拦截）
- PR 门闩 → 恒输出 0（从不拦截）
- 过时 Issue 清理 → 恒输出「无过时的失败 Issue」（从不关闭）

本地复现：`GITHUB_ACTIONS=true` 且无 GH_TOKEN 时三个脚本分别输出 `0` / `0` / `无过时的失败 Issue`（exit 0），与 CI 行为一致。

## 修复

1. 三个脚本补 `GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"` 兜底（与 open-issue.sh / push-upgrade-pr.sh 同双层防御，显式 GH_TOKEN 优先）
2. `upstream-check.yml` 三个步骤显式透传 `GH_TOKEN: ${{ github.token }}`
3. `check-issue-gate.sh` 版本匹配改为边界正则（原 `contains` 会让 0.2.0 误匹配 0.2.0-rc.1），与 check-pr-gate.sh / upgrade-dsh.sh 对齐

## 验证

- 新增 4 条单测（3 条兜底 + 1 条边界）：**56/56 通过**
- shellcheck、YAML 解析通过
- 门闩/清理在 CI 中真实生效需合并后下一次带 `should_upgrade=true` 的运行实证